### PR TITLE
feat: manual plant placement and grass empty plots

### DIFF
--- a/docs/superpowers/plans/2026-03-16-config-visuals-economy.md
+++ b/docs/superpowers/plans/2026-03-16-config-visuals-economy.md
@@ -1,0 +1,1562 @@
+# Config, Visuals & Economy Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add settings system, color palettes, 5 breathing visualizers, exotic ASCII plants with lore, garden encyclopedia, and reworked economy with independent difficulty/price controls.
+
+**Architecture:** Config persisted via node-persist alongside existing breathing data. Palette and visualizer are pure-function systems consumed by the overlay renderer. Lore is a static data module consumed by shop and encyclopedia. All new menu options route through the existing enquirer-based CLI menu.
+
+**Tech Stack:** TypeScript, chalk v4, enquirer, node-persist, ANSI escape sequences
+
+**Spec:** `docs/superpowers/specs/2026-03-16-config-visuals-economy-design.md`
+
+---
+
+## Chunk 1: Foundation (Config, Lore Data, Exotic Plants)
+
+### Task 1: Config System
+
+**Files:**
+- Create: `src/config.ts`
+- Modify: `src/storage.ts`
+
+- [ ] **Step 1: Create `src/config.ts` with types, defaults, palettes, difficulty/price tables, load/save**
+
+```typescript
+import storage from "node-persist";
+import chalk from "chalk";
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export type PaletteName = "garden" | "ocean" | "sunset" | "monochrome" | "aurora";
+export type DifficultyName = "chill" | "normal" | "focused" | "monk" | "ascetic";
+export type PriceScaleName = "cheap" | "normal" | "expensive" | "premium" | "luxury";
+export type VisualizerName = "progress-bar" | "circle" | "wave" | "orb" | "particles";
+
+export interface Config {
+  colorPalette: PaletteName;
+  difficulty: DifficultyName;
+  priceScale: PriceScaleName;
+  visualizer: VisualizerName;
+}
+
+export interface Palette {
+  name: string;
+  description: string;
+  primary: chalk.Chalk;
+  secondary: chalk.Chalk;
+  accent: chalk.Chalk;
+  dim: chalk.Chalk;
+  inhale: chalk.Chalk;
+  exhale: chalk.Chalk;
+  hold: chalk.Chalk;
+  bar: chalk.Chalk;
+  garden: chalk.Chalk;
+}
+
+export interface DifficultyTier {
+  name: DifficultyName;
+  ticksPerCoin: number;
+  description: string;
+}
+
+export interface PriceScaleTier {
+  name: PriceScaleName;
+  multiplier: number;
+  description: string;
+}
+
+// ─── Defaults ───────────────────────────────────────────────────────
+
+export const defaultConfig: Config = {
+  colorPalette: "garden",
+  difficulty: "chill",
+  priceScale: "normal",
+  visualizer: "progress-bar",
+};
+
+// ─── Palettes ───────────────────────────────────────────────────────
+
+export const palettes: Record<PaletteName, Palette> = {
+  garden: {
+    name: "Garden",
+    description: "Lush greens and earthy tones",
+    primary: chalk.cyan.bold,
+    secondary: chalk.green,
+    accent: chalk.cyan,
+    dim: chalk.dim,
+    inhale: chalk.cyan.bold,
+    exhale: chalk.green.bold,
+    hold: chalk.yellow.bold,
+    bar: chalk.cyan,
+    garden: chalk.green,
+  },
+  ocean: {
+    name: "Ocean",
+    description: "Cool blues and deep teals",
+    primary: chalk.blue.bold,
+    secondary: chalk.blueBright,
+    accent: chalk.cyanBright,
+    dim: chalk.dim,
+    inhale: chalk.cyanBright.bold,
+    exhale: chalk.blue.bold,
+    hold: chalk.blueBright.bold,
+    bar: chalk.blue,
+    garden: chalk.cyanBright,
+  },
+  sunset: {
+    name: "Sunset",
+    description: "Warm oranges and soft magentas",
+    primary: chalk.hex("#FF6B35").bold,
+    secondary: chalk.yellow,
+    accent: chalk.magenta,
+    dim: chalk.dim,
+    inhale: chalk.hex("#FF6B35").bold,
+    exhale: chalk.magenta.bold,
+    hold: chalk.yellow.bold,
+    bar: chalk.hex("#FF6B35"),
+    garden: chalk.yellow,
+  },
+  monochrome: {
+    name: "Monochrome",
+    description: "Clean whites and soft grays",
+    primary: chalk.white.bold,
+    secondary: chalk.gray,
+    accent: chalk.whiteBright,
+    dim: chalk.dim,
+    inhale: chalk.white.bold,
+    exhale: chalk.gray.bold,
+    hold: chalk.whiteBright.bold,
+    bar: chalk.white,
+    garden: chalk.whiteBright,
+  },
+  aurora: {
+    name: "Aurora",
+    description: "Vivid purples and northern greens",
+    primary: chalk.magenta.bold,
+    secondary: chalk.green,
+    accent: chalk.cyan,
+    dim: chalk.dim,
+    inhale: chalk.magenta.bold,
+    exhale: chalk.green.bold,
+    hold: chalk.cyan.bold,
+    bar: chalk.magenta,
+    garden: chalk.greenBright,
+  },
+};
+
+// ─── Difficulty tiers ───────────────────────────────────────────────
+
+export const difficultyTiers: DifficultyTier[] = [
+  { name: "chill", ticksPerCoin: 1, description: "A gentle pace. Coins flow freely." },
+  { name: "normal", ticksPerCoin: 5, description: "Steady growth. Patience rewarded." },
+  { name: "focused", ticksPerCoin: 15, description: "Deliberate progress. Each coin earned." },
+  { name: "monk", ticksPerCoin: 30, description: "Deep practice. Gardens grow slowly." },
+  { name: "ascetic", ticksPerCoin: 60, description: "One breath, one coin. True mastery." },
+];
+
+// ─── Price scale tiers ──────────────────────────────────────────────
+
+export const priceScaleTiers: PriceScaleTier[] = [
+  { name: "cheap", multiplier: 1, description: "Bargain garden. Everything's on sale." },
+  { name: "normal", multiplier: 2, description: "Fair prices for fair flora." },
+  { name: "expensive", multiplier: 3, description: "Quality costs. Choose wisely." },
+  { name: "premium", multiplier: 5, description: "Luxury botanicals. Worth the wait." },
+  { name: "luxury", multiplier: 8, description: "Only the most devoted gardeners." },
+];
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+export function getPalette(config: Config): Palette {
+  return palettes[config.colorPalette];
+}
+
+export function getDifficultyTier(config: Config): DifficultyTier {
+  return difficultyTiers.find((t) => t.name === config.difficulty)!;
+}
+
+export function getPriceMultiplier(config: Config): number {
+  return priceScaleTiers.find((t) => t.name === config.priceScale)!.multiplier;
+}
+
+// ─── Persistence ────────────────────────────────────────────────────
+
+export async function loadConfig(): Promise<Config> {
+  const stored = (await storage.getItem("config")) || {};
+  return { ...defaultConfig, ...stored };
+}
+
+export async function saveConfig(config: Config): Promise<void> {
+  await storage.setItem("config", config);
+}
+```
+
+- [ ] **Step 2: Add `discovered` to `BreathingData` in `src/storage.ts` and add migration backfill**
+
+In `src/storage.ts`, update the `BreathingData` interface and `defaultData`, and add backfill logic to `loadData()`:
+
+```typescript
+// Add to BreathingData interface:
+  discovered: string[];
+
+// Add to defaultData:
+  discovered: [],
+
+// Update loadData() to backfill discovered from existing plants:
+export async function loadData(): Promise<BreathingData> {
+  const storedData = (await storage.getItem("breathingData")) || {};
+  const data = { ...defaultData, ...storedData };
+  // Backfill discovered from existing plants if missing
+  if (!storedData.discovered && data.plants.length > 0) {
+    data.discovered = [...new Set(data.plants.map((p: Plant) => p.type))];
+    await saveData(data);
+  }
+  return data;
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd /Users/colinmacrae/projects/calm-garden-cli && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/config.ts src/storage.ts
+git commit -m "feat: add config system with palettes, difficulty, and price scaling"
+```
+
+---
+
+### Task 2: Plant Lore Data
+
+**Files:**
+- Create: `src/const/lore.ts`
+
+- [ ] **Step 1: Create `src/const/lore.ts` with all plant latin names and lore**
+
+```typescript
+export interface PlantLore {
+  latin: string;
+  lore: string;
+}
+
+export const plantLore: Record<string, PlantLore> = {
+  // ── Common ──
+  seedling: {
+    latin: "Germinula humilis",
+    lore: "The humblest beginning. Ancient gardeners believed planting one at dawn would bring clarity for the day ahead.",
+  },
+  herb: {
+    latin: "Herba tranquilla",
+    lore: "A calming herb whose scent sharpens the mind. Tea brewed from its leaves is said to make worries feel smaller.",
+  },
+  leaves: {
+    latin: "Folia susurrens",
+    lore: "These whispering leaves rustle even without wind. Monks keep them to remind themselves that stillness is never truly silent.",
+  },
+  arugula: {
+    latin: "Eruca amara",
+    lore: "Bitter and bold. Peasant farmers chewed it before meditation, claiming the sharp taste anchored them to the present.",
+  },
+  mushroom: {
+    latin: "Fungus mysticus",
+    lore: "Appears overnight in well-tended gardens. Its spores carry a faint scent of petrichor and forgotten dreams.",
+  },
+  rock: {
+    latin: "Petra immota",
+    lore: "Not technically a plant. Gardeners place it as a reminder that some things need not grow to have purpose.",
+  },
+
+  // ── Uncommon ──
+  daisy: {
+    latin: "Bellis serenium",
+    lore: "Blooms only in gardens tended with consistent breath. A symbol of patience in the ancient gardening orders.",
+  },
+  poppy: {
+    latin: "Papaver somnialis",
+    lore: "Its petals droop like heavy eyelids. Historically placed beside beds to welcome restful sleep.",
+  },
+  cactus: {
+    latin: "Cactus stoicus",
+    lore: "Thrives on neglect. Desert philosophers admired its ability to endure long silences.",
+  },
+  bamboo: {
+    latin: "Bambusa rapida",
+    lore: "Grows a full inch during a single breathing session. Or so they claim. Nobody has actually measured.",
+  },
+  "four-leaf-clover": {
+    latin: "Trifolium fortunae",
+    lore: "One leaf for hope, one for faith, one for love, one for breath. Finding one is said to double your next coin harvest.",
+  },
+  "maple-leaf": {
+    latin: "Acer contemplans",
+    lore: "Falls slowly and deliberately, as if demonstrating the exhale phase to anyone watching.",
+  },
+  tomato: {
+    latin: "Lycopersicum anxius",
+    lore: "Technically a fruit. Grows redder the more you worry about whether it's a fruit or a vegetable.",
+  },
+  tulip: {
+    latin: "Tulipa composita",
+    lore: "Opens at sunrise, closes at sunset. Dutch merchants once traded entire breathing sessions for a single bulb.",
+  },
+
+  // ── Rare ──
+  sunflower: {
+    latin: "Helianthus devotus",
+    lore: "Always faces the gardener. Some find this comforting. Others find it unnerving.",
+  },
+  "pink-rose": {
+    latin: "Rosa spiritus",
+    lore: "Petals arranged in a perfect golden spiral. Smells faintly of the last thing that made you happy.",
+  },
+  hibiscus: {
+    latin: "Hibiscus ignis",
+    lore: "Burns a deep crimson at the center. Tropical healers prescribed staring at it for exactly four breaths.",
+  },
+  iris: {
+    latin: "Iris oraculum",
+    lore: "Named for the messenger goddess. Said to deliver insights to gardeners who tend it during the hold phase.",
+  },
+  marigold: {
+    latin: "Calendula vigilans",
+    lore: "Repels unwanted thoughts the way it repels unwanted insects. Effective in both cases.",
+  },
+  evergreen: {
+    latin: "Pinus aeternus",
+    lore: "Never loses its needles. A popular gift between monks, symbolizing commitment to daily practice.",
+  },
+  tree: {
+    latin: "Arbor magnus",
+    lore: "Takes a hundred sessions to fully appreciate. Provides shade for all the smaller plants in your garden.",
+  },
+  palm: {
+    latin: "Palma placida",
+    lore: "Sways gently even indoors. Scientists remain baffled. Gardeners remain unbothered.",
+  },
+
+  // ── Exotic ──
+  "fern-glyph": {
+    latin: "Filix inscripta",
+    lore: "Its fronds unfurl in patterns that ancient monks used as meditation guides. Said to improve focus when planted near sitting stones.",
+  },
+  "star-moss": {
+    latin: "Muscus stellaris",
+    lore: "Bioluminescent moss harvested from cave ceilings. Glows faintly at night, guiding lost travelers back to their gardens.",
+  },
+  "rune-sprout": {
+    latin: "Runicus germinus",
+    lore: "Sprouts in the shape of old Norse runes. Druids once read fortunes in the direction of its growth.",
+  },
+  "hex-bloom": {
+    latin: "Hexagonia flora",
+    lore: "A crystalline flower with perfectly hexagonal petals. Mathematicians prize it; bees find it unsettling.",
+  },
+  "sigil-vine": {
+    latin: "Vitis sigilum",
+    lore: "A twisting vine that grows in circular patterns. Tibetan gardeners train it into prayer wheels.",
+  },
+  "eye-cluster": {
+    latin: "Oculus multiplicis",
+    lore: "A deeply unsettling organism with multiple eye-like seed pods. Watches over the garden. Nobody asked it to.",
+  },
+  "spiral-fern": {
+    latin: "Spiralis perpetua",
+    lore: "Grows in a perfect logarithmic spiral. Fibonacci himself kept one on his desk, or so the story goes.",
+  },
+  "thorn-script": {
+    latin: "Spina literata",
+    lore: "Thorny stems that form legible text in a forgotten language. Translations are always unsettlingly personal.",
+  },
+
+  // ── Epic ──
+  lotus: {
+    latin: "Nelumbo illuminata",
+    lore: "Grows from mud into perfect beauty. The central metaphor of seven different philosophical traditions, all of which claim to have noticed it first.",
+  },
+  orchid: {
+    latin: "Orchis enigmatica",
+    lore: "Refuses to bloom on any predictable schedule. Botanists suspect it's doing this on purpose.",
+  },
+  "cherry-blossom": {
+    latin: "Prunus ephemera",
+    lore: "Blooms briefly and brilliantly. Japanese poets wrote that watching one fall teaches more about impermanence than any sutra.",
+  },
+  bonsai: {
+    latin: "Arbor minima disciplinae",
+    lore: "A full tree compressed into a pot through years of patient trimming. A masterwork of controlled growth.",
+  },
+
+  // ── Legendary ──
+  "dragon-fruit": {
+    latin: "Draconis fructus",
+    lore: "Scales like a dragon, sweetness like enlightenment. Only fruits in gardens where the owner has practiced for over an hour total.",
+  },
+  "crystal-flower": {
+    latin: "Crystallum floris",
+    lore: "Petals of pure quartz that refract light into mantras. Geologists insist it's impossible. It doesn't care.",
+  },
+  "golden-bloom": {
+    latin: "Aurum perpetuum",
+    lore: "Radiates a warm golden light. Ancient texts claim it can only be grown by someone who has truly exhaled their worries.",
+  },
+  "ancient-tree": {
+    latin: "Arbor antiquissima",
+    lore: "Older than the garden it's planted in. Older than the soil. Possibly older than time. Excellent shade.",
+  },
+};
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/const/lore.ts
+git commit -m "feat: add latin names and lore for all plants"
+```
+
+---
+
+### Task 3: Exotic Plants & Orchid Shop Entry
+
+**Files:**
+- Modify: `src/const/emoji.ts`
+- Modify: `src/shop/items.ts`
+
+- [ ] **Step 1: Add exotic plant characters to `src/const/emoji.ts`**
+
+Add these entries to `plantEmojis` (before the closing `} as const`), after the Legendary section:
+
+```typescript
+  // Exotic (ASCII/Unicode glyphs)
+  "fern-glyph": "❧",
+  "star-moss": "⍟",
+  "rune-sprout": "ᚡ",
+  "hex-bloom": "⌬",
+  "sigil-vine": "☸",
+  "eye-cluster": "ꙮ",
+  "spiral-fern": "ꝏ",
+  "thorn-script": "ᛝ",
+```
+
+Also add Orchid to the Epic section (it exists in the emoji map as `orchid: "🪻"` but is a duplicate of iris — give it a unique emoji):
+
+Change `orchid: "🪻"` to `orchid: "🌺"` (swap hibiscus and orchid emojis since orchid needs its own identity). Actually, looking at the emoji map, hibiscus already uses 🌺. Keep orchid as 🪻 — it's listed in Epic alongside iris in Rare, they just share an emoji. Leave as-is since the emoji map already has the orchid entry.
+
+- [ ] **Step 2: Add exotic plants and orchid to `src/shop/items.ts`**
+
+Add orchid to the Epic section and exotic plants as a new section. Insert after the Rare plants and before Epic:
+
+```typescript
+  // Exotic — 220-380 coins (ASCII/Unicode glyphs)
+  { name: "Fern Glyph", type: "fern-glyph", cost: 220, rarity: "exotic" },
+  { name: "Star Moss", type: "star-moss", cost: 240, rarity: "exotic" },
+  { name: "Hex Bloom", type: "hex-bloom", cost: 230, rarity: "exotic" },
+  { name: "Spiral Fern", type: "spiral-fern", cost: 260, rarity: "exotic" },
+  { name: "Rune Sprout", type: "rune-sprout", cost: 280, rarity: "exotic" },
+  { name: "Sigil Vine", type: "sigil-vine", cost: 300, rarity: "exotic" },
+  { name: "Thorn Script", type: "thorn-script", cost: 320, rarity: "exotic" },
+  { name: "Eye Cluster", type: "eye-cluster", cost: 380, rarity: "exotic" },
+```
+
+Add orchid to the Epic section:
+
+```typescript
+  { name: "Orchid", type: "orchid", cost: 450, rarity: "epic" },
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/const/emoji.ts src/shop/items.ts
+git commit -m "feat: add exotic ASCII plants and orchid shop entry"
+```
+
+---
+
+## Chunk 2: Visualizers
+
+### Task 4: Breathing Visualizers
+
+**Files:**
+- Create: `src/visualizers.ts`
+
+- [ ] **Step 1: Create `src/visualizers.ts` with all 5 visualizer functions**
+
+```typescript
+import { Palette } from "./config";
+
+export type VisualizerFn = (
+  progress: number,
+  phase: string,
+  palette: Palette,
+  width: number
+) => string[];
+
+// ─── Progress Bar ───────────────────────────────────────────────────
+
+function progressBar(
+  progress: number,
+  _phase: string,
+  palette: Palette,
+  width: number
+): string[] {
+  const barWidth = Math.min(30, width - 10);
+  const filled = Math.round(progress * barWidth);
+  const bar =
+    palette.bar("█".repeat(filled)) +
+    palette.dim("░".repeat(barWidth - filled));
+  return [bar];
+}
+
+// ─── Circle ─────────────────────────────────────────────────────────
+
+function circle(
+  progress: number,
+  _phase: string,
+  palette: Palette,
+  _width: number
+): string[] {
+  // Radius scales from 1 to 4 based on progress
+  const maxRadius = 4;
+  const radius = Math.max(1, Math.round(progress * maxRadius));
+  const size = radius * 2 + 1;
+  const lines: string[] = [];
+
+  for (let y = 0; y < size; y++) {
+    let row = "";
+    for (let x = 0; x < size * 2; x++) {
+      const dx = (x / 2) - radius;
+      const dy = y - radius;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+
+      if (Math.abs(dist - radius) < 0.6) {
+        row += palette.accent("·");
+      } else if (dist < 0.8) {
+        row += palette.bar("●");
+      } else if (dist < radius * 0.5 && radius > 2) {
+        row += palette.dim("◦");
+      } else {
+        row += " ";
+      }
+    }
+    lines.push(row);
+  }
+  return lines;
+}
+
+// ─── Wave ───────────────────────────────────────────────────────────
+
+function wave(
+  progress: number,
+  _phase: string,
+  palette: Palette,
+  width: number
+): string[] {
+  const waveWidth = Math.min(40, width - 10);
+  const rows = 7;
+  const amplitude = Math.max(0.5, progress * 3);
+  const midRow = Math.floor(rows / 2);
+  const chars = ["∿", "≈", "∼", "~"];
+  const grid: string[][] = [];
+
+  for (let r = 0; r < rows; r++) {
+    grid.push(new Array(waveWidth).fill(" "));
+  }
+
+  for (let x = 0; x < waveWidth; x++) {
+    const t = (x / waveWidth) * Math.PI * 2;
+    const y = Math.sin(t + progress * Math.PI) * amplitude;
+    const row = Math.round(midRow - y);
+    if (row >= 0 && row < rows) {
+      const charIdx = Math.floor(Math.abs(y) / amplitude * (chars.length - 1));
+      const ch = chars[Math.min(charIdx, chars.length - 1)];
+      grid[row][x] = palette.accent(ch);
+    }
+  }
+
+  return grid.map((row) => row.join(""));
+}
+
+// ─── Orb ────────────────────────────────────────────────────────────
+
+function orb(
+  progress: number,
+  _phase: string,
+  palette: Palette,
+  _width: number
+): string[] {
+  const maxRadius = 4;
+  const radius = Math.max(1, Math.round(progress * maxRadius));
+  const size = maxRadius * 2 + 1;
+  const center = maxRadius;
+  const ringChars = ["✦", "*", "•", "°", "·"];
+  const lines: string[] = [];
+
+  for (let y = 0; y < size; y++) {
+    let row = "";
+    for (let x = 0; x < size * 2; x++) {
+      const dx = (x / 2) - center;
+      const dy = y - center;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+
+      if (dist < 0.8) {
+        row += palette.bar("✦");
+      } else if (dist <= radius) {
+        const ringIndex = Math.min(
+          Math.floor((dist / radius) * (ringChars.length - 1)),
+          ringChars.length - 1
+        );
+        const ch = ringChars[ringIndex];
+        if (dist <= radius * 0.4) {
+          row += palette.bar(ch);
+        } else if (dist <= radius * 0.7) {
+          row += palette.accent(ch);
+        } else {
+          row += palette.dim(ch);
+        }
+      } else {
+        row += " ";
+      }
+    }
+    lines.push(row);
+  }
+  return lines;
+}
+
+// ─── Particles ──────────────────────────────────────────────────────
+
+function particles(
+  progress: number,
+  _phase: string,
+  palette: Palette,
+  width: number
+): string[] {
+  const particleWidth = Math.min(30, width - 10);
+  const rows = 7;
+  const chars = ["·", "°", "•", "✧", "✦"];
+  const grid: string[][] = [];
+
+  for (let r = 0; r < rows; r++) {
+    grid.push(new Array(particleWidth).fill(" "));
+  }
+
+  // Seed-based particle positions (deterministic per-position, animated by progress)
+  const seeds = [3, 7, 11, 15, 19, 23, 27, 5, 13, 21, 9, 17, 25, 1, 29];
+  for (let i = 0; i < seeds.length; i++) {
+    const x = seeds[i] % particleWidth;
+    // Particles rise with progress (inhale) or fall (lower progress)
+    const baseRow = rows - 1 - (i % rows);
+    const offset = Math.round(progress * (rows - 1));
+    const row = baseRow - offset + Math.floor(i / rows);
+    const wrappedRow = ((row % rows) + rows) % rows;
+
+    if (wrappedRow >= 0 && wrappedRow < rows && x < particleWidth) {
+      const ch = chars[i % chars.length];
+      const colorFn = i % 3 === 0 ? palette.bar : i % 3 === 1 ? palette.accent : palette.dim;
+      grid[wrappedRow][x] = colorFn(ch);
+    }
+  }
+
+  return grid.map((row) => row.join(""));
+}
+
+// ─── Registry ───────────────────────────────────────────────────────
+
+export const visualizers: Record<string, VisualizerFn> = {
+  "progress-bar": progressBar,
+  circle,
+  wave,
+  orb,
+  particles,
+};
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/visualizers.ts
+git commit -m "feat: add 5 breathing visualizers (bar, circle, wave, orb, particles)"
+```
+
+---
+
+## Chunk 3: Settings Menu & Encyclopedia
+
+### Task 5: Settings Menu
+
+**Files:**
+- Create: `src/settings.ts`
+
+- [ ] **Step 1: Create `src/settings.ts`**
+
+```typescript
+import { prompt } from "enquirer";
+import chalk from "chalk";
+import {
+  Config,
+  palettes,
+  PaletteName,
+  difficultyTiers,
+  DifficultyName,
+  priceScaleTiers,
+  PriceScaleName,
+  VisualizerName,
+  saveConfig,
+  getPalette,
+} from "./config";
+import { clearConsole } from "./utils";
+
+export async function showSettings(config: Config): Promise<void> {
+  while (true) {
+    clearConsole();
+    const palette = getPalette(config);
+    console.log(palette.primary("\n⚙️  Settings\n"));
+
+    const response = await prompt<{ setting: string }>({
+      type: "select",
+      name: "setting",
+      message: "Choose a setting to change:",
+      choices: [
+        {
+          name: "palette",
+          message: `🎨 Color Palette`,
+          hint: ` (current: ${palettes[config.colorPalette].name})`,
+        },
+        {
+          name: "difficulty",
+          message: `⚡ Difficulty`,
+          hint: ` (current: ${config.difficulty})`,
+        },
+        {
+          name: "priceScale",
+          message: `💰 Price Scale`,
+          hint: ` (current: ${config.priceScale})`,
+        },
+        {
+          name: "visualizer",
+          message: `🌀 Visualizer`,
+          hint: ` (current: ${config.visualizer})`,
+        },
+        { name: "back", message: "↩ Back" },
+      ],
+    });
+
+    if (response.setting === "back") return;
+
+    switch (response.setting) {
+      case "palette":
+        await changePalette(config);
+        break;
+      case "difficulty":
+        await changeDifficulty(config);
+        break;
+      case "priceScale":
+        await changePriceScale(config);
+        break;
+      case "visualizer":
+        await changeVisualizer(config);
+        break;
+    }
+
+    await saveConfig(config);
+  }
+}
+
+async function changePalette(config: Config): Promise<void> {
+  const choices = (Object.keys(palettes) as PaletteName[]).map((key) => ({
+    name: key,
+    message: `${palettes[key].name}`,
+    hint: ` — ${palettes[key].description}${key === config.colorPalette ? " (current)" : ""}`,
+  }));
+
+  const response = await prompt<{ choice: PaletteName }>({
+    type: "select",
+    name: "choice",
+    message: "Select color palette:",
+    choices,
+  });
+
+  config.colorPalette = response.choice;
+}
+
+async function changeDifficulty(config: Config): Promise<void> {
+  const choices = difficultyTiers.map((tier) => ({
+    name: tier.name,
+    message: `${tier.name}`,
+    hint: ` — ${tier.ticksPerCoin} tick${tier.ticksPerCoin > 1 ? "s" : ""}/coin — ${tier.description}${tier.name === config.difficulty ? " (current)" : ""}`,
+  }));
+
+  const response = await prompt<{ choice: DifficultyName }>({
+    type: "select",
+    name: "choice",
+    message: "Select difficulty:",
+    choices,
+  });
+
+  config.difficulty = response.choice;
+}
+
+async function changePriceScale(config: Config): Promise<void> {
+  const choices = priceScaleTiers.map((tier) => ({
+    name: tier.name,
+    message: `${tier.name}`,
+    hint: ` — ${tier.multiplier}x prices — ${tier.description}${tier.name === config.priceScale ? " (current)" : ""}`,
+  }));
+
+  const response = await prompt<{ choice: PriceScaleName }>({
+    type: "select",
+    name: "choice",
+    message: "Select price scale:",
+    choices,
+  });
+
+  config.priceScale = response.choice;
+}
+
+async function changeVisualizer(config: Config): Promise<void> {
+  const visualizerDescriptions: Record<VisualizerName, string> = {
+    "progress-bar": "Classic progress bar",
+    circle: "Expanding/contracting circle",
+    wave: "Flowing sine wave",
+    orb: "Pulsing radial orb",
+    particles: "Floating particles",
+  };
+
+  const choices = (Object.keys(visualizerDescriptions) as VisualizerName[]).map((key) => ({
+    name: key,
+    message: key,
+    hint: ` — ${visualizerDescriptions[key]}${key === config.visualizer ? " (current)" : ""}`,
+  }));
+
+  const response = await prompt<{ choice: VisualizerName }>({
+    type: "select",
+    name: "choice",
+    message: "Select breathing visualizer:",
+    choices,
+  });
+
+  config.visualizer = response.choice;
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/settings.ts
+git commit -m "feat: add settings menu for palette, difficulty, price, visualizer"
+```
+
+---
+
+### Task 6: Encyclopedia
+
+**Files:**
+- Create: `src/encyclopedia.ts`
+
+- [ ] **Step 1: Create `src/encyclopedia.ts`**
+
+```typescript
+import chalk from "chalk";
+import { prompt } from "enquirer";
+import { loadData, BreathingData } from "./storage";
+import { shopItems } from "./shop/items";
+import { plantLore } from "./const/lore";
+import { emojis, EmojiKey } from "./const/emoji";
+import { Config, getPalette } from "./config";
+import { clearConsole } from "./utils";
+
+const rarityOrder = ["common", "uncommon", "rare", "exotic", "epic", "legendary"];
+
+export async function showEncyclopedia(config: Config): Promise<void> {
+  const data = await loadData();
+  const palette = getPalette(config);
+
+  // Only show plantable items (exclude utility items)
+  const plants = shopItems.filter((item) => item.rarity);
+  const discovered = new Set(data.discovered || []);
+  const totalDiscovered = plants.filter((p) => discovered.has(p.type)).length;
+
+  clearConsole();
+  console.log(palette.primary(`\n🌿  ENCYCLOPEDIA  🌿     ${totalDiscovered}/${plants.length} discovered\n`));
+
+  const grouped: Record<string, typeof plants> = {};
+  for (const plant of plants) {
+    const rarity = plant.rarity || "common";
+    if (!grouped[rarity]) grouped[rarity] = [];
+    grouped[rarity].push(plant);
+  }
+
+  const choices: Array<{ name: string; message: string; hint?: string }> = [];
+
+  for (const rarity of rarityOrder) {
+    if (!grouped[rarity]) continue;
+    choices.push({
+      name: `header-${rarity}`,
+      message: palette.secondary(`── ${rarity.charAt(0).toUpperCase() + rarity.slice(1)} ──`),
+      hint: "",
+    });
+
+    for (const plant of grouped[rarity]) {
+      const isDiscovered = discovered.has(plant.type);
+      const emoji = emojis[plant.type as EmojiKey] || "?";
+      const lore = plantLore[plant.type];
+      const ownedCount = data.plants.filter((p: { type: string }) => p.type === plant.type).length;
+
+      if (isDiscovered) {
+        choices.push({
+          name: plant.type,
+          message: `${emoji} ${plant.name} — ${lore?.latin || "???"}`,
+          hint: ownedCount > 0 ? ` (owned: ${ownedCount})` : " ✓",
+        });
+      } else {
+        choices.push({
+          name: plant.type,
+          message: palette.dim(`🔒 ??? — ???`),
+          hint: "",
+        });
+      }
+    }
+  }
+
+  choices.push({ name: "back", message: "↩ Back" });
+
+  const response = await prompt<{ plant: string }>({
+    type: "select",
+    name: "plant",
+    message: "Select a plant to view details:",
+    choices: choices.filter((c) => !c.name.startsWith("header-")),
+  });
+
+  if (response.plant === "back") return;
+
+  if (discovered.has(response.plant)) {
+    await showPlantDetail(response.plant, data, config);
+  }
+}
+
+async function showPlantDetail(
+  plantType: string,
+  data: BreathingData,
+  config: Config
+): Promise<void> {
+  const palette = getPalette(config);
+  const lore = plantLore[plantType];
+  const item = shopItems.find((i) => i.type === plantType);
+  const emoji = emojis[plantType as EmojiKey] || "?";
+  const ownedCount = data.plants.filter((p: { type: string }) => p.type === plantType).length;
+
+  clearConsole();
+  console.log("");
+  console.log(palette.primary(`  ${emoji}  ${item?.name || plantType}`));
+  console.log(palette.accent(`  ${lore?.latin || "Unknown species"}`));
+  console.log("");
+  console.log(palette.dim(`  Rarity: ${item?.rarity || "unknown"}`));
+  console.log(palette.dim(`  Base cost: ${item?.cost || "?"} coins`));
+  console.log(palette.dim(`  Owned: ${ownedCount}`));
+  console.log("");
+  console.log(`  "${lore?.lore || "No information available."}"`);
+  console.log("");
+
+  await prompt<{ action: string }>({
+    type: "select",
+    name: "action",
+    message: "",
+    choices: [{ name: "back", message: "↩ Back" }],
+  });
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/encyclopedia.ts
+git commit -m "feat: add garden encyclopedia with discovery tracking"
+```
+
+---
+
+## Chunk 4: Integration (Overlay, Shop, Menu, Cleanup)
+
+### Task 7: Update Breathing Overlay
+
+**Files:**
+- Modify: `src/overlay.ts`
+
+This is the largest modification. The overlay needs to:
+1. Accept and use config for palette colors
+2. Use the selected visualizer instead of hardcoded progress bar
+3. Implement difficulty-based coin earning (tick counter)
+
+- [ ] **Step 1: Update overlay imports and state**
+
+At the top of `src/overlay.ts`, add config imports and a tick counter:
+
+```typescript
+// Add these imports:
+import { Config, getPalette, getDifficultyTier, Palette } from "./config";
+import { visualizers } from "./visualizers";
+
+// Add to state section:
+let config: Config;
+let palette: Palette;
+let tickCounter = 0;
+```
+
+- [ ] **Step 2: Update the `render()` function to use palette and visualizer**
+
+Replace the hardcoded colors and progress bar in `render()`:
+
+```typescript
+function render(): void {
+  const w = getTermWidth();
+
+  clearScreen();
+  moveTo(1, 1);
+
+  const lines: string[] = [];
+
+  lines.push("");
+  lines.push(center(palette.primary("🌿  calm garden  🌿"), w));
+  lines.push(center(palette.dim(patternName), w));
+  lines.push("");
+
+  if (paused) {
+    lines.push(center(palette.hold("⏸  PAUSED"), w));
+  } else {
+    const phaseColor =
+      currentPhaseName === "Inhale"
+        ? palette.inhale
+        : currentPhaseName === "Exhale"
+        ? palette.exhale
+        : palette.hold;
+    lines.push(center(phaseColor(`${currentPhaseName}`), w));
+  }
+
+  lines.push("");
+
+  // Visualizer
+  const progress =
+    currentPhaseDuration > 0 ? currentPhaseSecond / currentPhaseDuration : 0;
+  const vizLines = visualizers[config.visualizer](
+    progress,
+    currentPhaseName,
+    palette,
+    w
+  );
+  for (const line of vizLines) {
+    lines.push(center(line, w));
+  }
+  lines.push(
+    center(palette.dim(`${currentPhaseSecond}/${currentPhaseDuration}s`), w)
+  );
+
+  lines.push("");
+
+  // Garden
+  const gardenSize = data.gardenSize;
+  const emptyPlot = "🌱";
+  for (let y = 0; y < gardenSize; y++) {
+    let row = "";
+    for (let x = 0; x < gardenSize; x++) {
+      const plant = data.plants.find(
+        (p: { x: number; y: number; type: string }) => p.x === x && p.y === y
+      );
+      row += plant
+        ? emojis[plant.type as EmojiKey] || emptyPlot
+        : emptyPlot;
+    }
+    lines.push(center(row, w));
+  }
+
+  lines.push("");
+
+  lines.push(
+    center(
+      palette.dim(`☀️ ${data.coins}`) +
+        palette.dim("  ⏱ ") +
+        palette.dim(formatTime(sessionTime)),
+      w
+    )
+  );
+
+  lines.push("");
+
+  lines.push(
+    center(
+      palette.dim("[space] pause/resume  [m] menu  [q] back"),
+      w
+    )
+  );
+
+  process.stdout.write(lines.join("\n"));
+}
+```
+
+- [ ] **Step 3: Update coin earning in `breatheLoop()` to use difficulty tick counter**
+
+Replace `data.coins++` with tick-based earning:
+
+```typescript
+// In breatheLoop(), replace:
+//   data.coins++;
+// With:
+        tickCounter++;
+        const tier = getDifficultyTier(config);
+        if (tickCounter >= tier.ticksPerCoin) {
+          data.coins++;
+          tickCounter = 0;
+        }
+```
+
+- [ ] **Step 4: Update `startBreathingOverlay()` to accept and use config**
+
+Change the function signature and initialization:
+
+```typescript
+export async function startBreathingOverlay(
+  patternType: string,
+  userConfig: Config
+): Promise<void> {
+  // Reset state for each session
+  paused = false;
+  running = true;
+  sessionTime = 0;
+  menuOpen = false;
+  menuIndex = 0;
+  tickCounter = 0;
+
+  config = userConfig;
+  palette = getPalette(config);
+
+  data = await loadData();
+  // ... rest unchanged
+```
+
+- [ ] **Step 5: Update menu rendering to use palette**
+
+In `renderMenu()`, replace `chalk.cyan.bold` and `chalk.dim` with palette equivalents:
+
+```typescript
+function renderMenu(): void {
+  const w = getTermWidth();
+  clearScreen();
+  moveTo(1, 1);
+
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(center(palette.primary("🌿  select pattern  🌿"), w));
+  lines.push("");
+
+  for (let i = 0; i < breathingPatterns.length; i++) {
+    const p = breathingPatterns[i];
+    const selected = i === menuIndex;
+    const prefix = selected ? palette.accent("▸ ") : "  ";
+    const text = selected
+      ? palette.accent(`${p.emoji} ${p.display}`)
+      : palette.dim(`${p.emoji} ${p.display}`);
+    lines.push(center(prefix + text, w));
+    lines.push(center(palette.dim(`  ${p.description}`), w));
+    lines.push("");
+  }
+
+  lines.push(
+    center(palette.dim("[↑↓] select  [enter] start  [m] back"), w)
+  );
+
+  process.stdout.write(lines.join("\n"));
+}
+```
+
+- [ ] **Step 6: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/overlay.ts
+git commit -m "feat: integrate config into breathing overlay (palette, visualizer, difficulty)"
+```
+
+---
+
+### Task 8: Update Shop with Price Scaling and Lore
+
+**Files:**
+- Modify: `src/shop/service.ts`
+- Modify: `src/shop/items.ts`
+- Modify: `src/shop/actions.ts`
+
+- [ ] **Step 1: Update `src/shop/items.ts` — add `getEffectivePrice()` and update `getPlantValue()`**
+
+Add import and helper function:
+
+```typescript
+import { Config, getPriceMultiplier } from "../config";
+
+export function getEffectivePrice(item: ShopItem, config: Config): number {
+  return Math.floor(item.cost * getPriceMultiplier(config));
+}
+
+// Update getPlantValue to accept config:
+export function getPlantValue(plant: Plant, config: Config): number {
+  const baseValue =
+    shopItems.find((item) => item.name === plant.name)?.cost || 10;
+  const growthMultiplier = 1 + (plant.growth - 1) * 0.1;
+  return Math.round(baseValue * growthMultiplier * getPriceMultiplier(config));
+}
+
+// Update calculateExpansionPrice to accept config:
+export function calculateExpansionPrice(currentSize: number, config: Config): number {
+  return Math.floor(100 * Math.pow(1.5, currentSize - 3) * getPriceMultiplier(config));
+}
+```
+
+- [ ] **Step 2: Update `src/shop/service.ts` — pass config, show lore, track discovery**
+
+Update `showShop` to accept config, show lore inline, and update discovered list:
+
+```typescript
+import { Config, getPalette } from "../config";
+import { plantLore } from "../const/lore";
+import { getEffectivePrice } from "./items";
+
+export async function showShop(config: Config): Promise<void> {
+  let data = await loadData();
+  initializeShopItems();
+  const palette = getPalette(config);
+
+  while (true) {
+    clearConsole();
+    console.log(palette.primary("🏪 Welcome to the Garden Shop!"));
+    console.log(palette.dim(`💰 You have ${data.coins} coins.`));
+    console.log(palette.dim(`🌳 Your garden size: ${data.gardenSize}x${data.gardenSize}\n`));
+
+    const choices = createShopMenu(data, config);
+
+    const response = await prompt<{ choice: string }>({
+      type: "select",
+      name: "choice",
+      message: "Choose an item to purchase:",
+      choices,
+    });
+
+    if (response.choice.includes("Exit")) break;
+
+    const item = shopItems.find((x) => response.choice.includes(x.name));
+
+    if (item) {
+      await purchaseItem(data, item, config);
+    } else {
+      console.log("Invalid selection. Please try again.");
+      await sleep(2000);
+    }
+  }
+}
+```
+
+Update `createShopMenu` to show effective prices and lore hints:
+
+```typescript
+function createShopMenu(
+  data: BreathingData,
+  config: Config
+): Array<{ name: string; value: number; hint: string }> {
+  const choices = shopItems.map((item, index) => {
+    const price = item.name === "Garden Expansion"
+      ? calculateExpansionPrice(data.gardenSize, config)
+      : getEffectivePrice(item, config);
+    const lore = plantLore[item.type];
+    const loreHint = lore ? ` — ${lore.latin}` : "";
+
+    return {
+      name:
+        item.name === "Garden Expansion"
+          ? `${item.emoji} ${item.name} (${data.gardenSize + 1}x${data.gardenSize + 1})`
+          : `${item.emoji} ${item.name}${loreHint}`,
+      value: index,
+      hint:
+        item.name === "Sell Plant"
+          ? " (sell a plant)"
+          : ` (${price} coins)`,
+    };
+  });
+  choices.push({ name: "🚪 Exit Shop", value: -1, hint: "Leave the shop" });
+  return choices;
+}
+```
+
+Update `purchaseItem` to pass config and track discovery:
+
+```typescript
+async function purchaseItem(
+  data: BreathingData,
+  item: ShopItem,
+  config: Config
+): Promise<void> {
+  const handlers: Record<string, () => Promise<void>> = {
+    "Sell Plant": async () => await handleSellPlant(data, item, config),
+    "Garden Expansion": async () => await handleGardenExpansion(data, config),
+    "Shuffle Garden": async () => await handleShuffleGarden(data, item, config),
+  };
+
+  const handler =
+    handlers[item.name] || (async () => {
+      await handleRegularPurchase(data, item, config);
+      // Track discovery
+      if (item.rarity && !data.discovered.includes(item.type)) {
+        data.discovered.push(item.type);
+      }
+    });
+
+  await handler();
+  await saveData(data);
+  await sleep(2000);
+}
+```
+
+- [ ] **Step 3: Update `src/shop/actions.ts` — use config for price calculations**
+
+Update all handler functions to accept config and use effective prices:
+
+```typescript
+import { Config } from "../config";
+import { getEffectivePrice } from "./items";
+
+// Update handleSellPlant signature:
+export async function handleSellPlant(
+  data: BreathingData,
+  item: ShopItem,
+  config: Config
+): Promise<void> {
+  // ... same logic but use getPlantValue(plant, config)
+}
+
+// Update handleGardenExpansion:
+export async function handleGardenExpansion(
+  data: BreathingData,
+  config: Config
+): Promise<void> {
+  const cost = calculateExpansionPrice(data.gardenSize, config);
+  // ... rest same
+}
+
+// Update handleShuffleGarden:
+export async function handleShuffleGarden(
+  data: BreathingData,
+  item: ShopItem,
+  config: Config
+): Promise<void> {
+  const cost = getEffectivePrice(item, config);
+  if (data.plants && data.plants.length > 1) {
+    shuffleGarden(data);
+    data.coins -= cost;
+    // ... rest same
+  }
+}
+
+// Update handleRegularPurchase:
+export async function handleRegularPurchase(
+  data: BreathingData,
+  item: ShopItem,
+  config: Config
+): Promise<void> {
+  const effectivePrice = getEffectivePrice(item, config);
+  const response: { quantity: number } = await prompt({
+    type: "numeral",
+    name: "quantity",
+    message: `How many ${item.name}s do you want to buy?`,
+    initial: 1,
+    min: 1,
+    max: Math.floor(data.coins / effectivePrice),
+  });
+
+  const quantity = response.quantity;
+  const totalCost = effectivePrice * quantity;
+  // ... rest same with totalCost
+}
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shop/service.ts src/shop/items.ts src/shop/actions.ts
+git commit -m "feat: integrate price scaling, lore display, and discovery tracking into shop"
+```
+
+---
+
+### Task 9: Update Main Menu & Clean Up Legacy Code
+
+**Files:**
+- Modify: `src/cli.ts`
+- Modify: `src/index.ts`
+- Modify: `src/breathe.ts`
+
+- [ ] **Step 1: Add Settings and Encyclopedia to `src/cli.ts` menu**
+
+Add two new choices to the `setupConfig()` main menu, before "Reset Data":
+
+```typescript
+      { name: "encyclopedia", message: "📖 Encyclopedia" },
+      { name: "settings", message: "⚙️  Settings" },
+```
+
+- [ ] **Step 2: Update `src/index.ts` to load config, route new actions, pass config to overlay and shop**
+
+```typescript
+import { showSettings } from "./settings";
+import { showEncyclopedia } from "./encyclopedia";
+import { loadConfig, Config } from "./config";
+
+async function main() {
+  await initStorage();
+  let config = await loadConfig();
+
+  const patterns = await getBreathingPatterns();
+  const patternSet = new Set(patterns.map((p) => p.name));
+  while (true) {
+    const { action } = await setupConfig();
+
+    if (patternSet.has(action)) {
+      config = await loadConfig(); // reload in case settings changed
+      await startBreathingOverlay(action, config);
+      continue;
+    }
+
+    switch (action) {
+      case "garden":
+        await showGarden();
+        break;
+      case "progress":
+        await showProgress();
+        break;
+      case "shop":
+        config = await loadConfig();
+        await showShop(config);
+        break;
+      case "encyclopedia":
+        config = await loadConfig();
+        await showEncyclopedia(config);
+        break;
+      case "settings":
+        config = await loadConfig();
+        await showSettings(config);
+        break;
+      case "reset":
+        await resetData();
+        break;
+      case "exit":
+        console.log("Thank you for using CLI Calm Garden!");
+        return;
+      default:
+        console.log("Invalid option. Please try again.");
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Remove legacy functions from `src/breathe.ts`**
+
+Remove `performBreathing()` and `startBreathing()` functions (lines 11-69). Keep `getCustomBreathingPatterns()` and `getBreathingPatterns()` which are still used. Also remove unused imports (`sleep`, `clearConsole`, `prompt`, `chalk`) that were only used by the removed functions.
+
+After cleanup, `breathe.ts` should contain only:
+
+```typescript
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+import { breathingPatterns } from "./const/patterns";
+import { BreathingPattern } from "./types/BreathingPattern";
+import path from "path";
+
+export async function getCustomBreathingPatterns(): Promise<BreathingPattern[]> {
+  // ... unchanged
+}
+
+export async function getBreathingPatterns(): Promise<BreathingPattern[]> {
+  // ... unchanged
+}
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 5: Build the project**
+
+Run: `npx tsc`
+Expected: Compiles successfully to `dist/`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli.ts src/index.ts src/breathe.ts
+git commit -m "feat: wire up settings, encyclopedia, and clean up legacy breathing code"
+```
+
+---
+
+### Task 10: Manual Smoke Test
+
+- [ ] **Step 1: Run the app and test the settings menu**
+
+Run: `npx ts-node src/index.ts`
+
+Verify:
+- Main menu shows Settings and Encyclopedia options
+- Settings menu lets you change all 4 options
+- Settings persist between sessions (exit and re-run)
+
+- [ ] **Step 2: Test breathing overlay with different visualizers and palettes**
+
+- Change visualizer to each option and start a breathing session
+- Change palette and verify colors update
+- Verify coins earn at the rate set by difficulty
+
+- [ ] **Step 3: Test shop with price scaling**
+
+- Change price scale and verify shop prices update
+- Buy an exotic plant
+- Verify it appears in the garden
+
+- [ ] **Step 4: Test encyclopedia**
+
+- View encyclopedia after buying some plants
+- Verify discovered plants show full details
+- Verify undiscovered plants show as locked
+
+- [ ] **Step 5: Final commit if any fixes needed**
+
+```bash
+git add -A
+git commit -m "fix: address issues found during smoke testing"
+```

--- a/docs/superpowers/specs/2026-03-16-config-visuals-economy-design.md
+++ b/docs/superpowers/specs/2026-03-16-config-visuals-economy-design.md
@@ -1,0 +1,360 @@
+# Config, Visuals & Economy Overhaul
+
+## Overview
+
+Add a settings system, multiple breathing visualizers, color palettes, exotic ASCII plants with lore, a garden encyclopedia, and a reworked economy with independent difficulty and price scaling controls.
+
+## 1. Config System
+
+### Storage
+
+Config persisted as a `config` key in the existing `~/.breathe-app/` node-persist store, alongside `breathingData`.
+
+### Shape
+
+```typescript
+interface Config {
+  colorPalette: "garden" | "ocean" | "sunset" | "monochrome" | "aurora";
+  difficulty: "chill" | "normal" | "focused" | "monk" | "ascetic";
+  priceScale: "cheap" | "normal" | "expensive" | "premium" | "luxury";
+  visualizer: "progress-bar" | "circle" | "wave" | "orb" | "particles";
+}
+```
+
+### Defaults
+
+```typescript
+const defaultConfig: Config = {
+  colorPalette: "garden",
+  difficulty: "chill",
+  priceScale: "normal",
+  visualizer: "progress-bar",
+};
+```
+
+Defaults use the easiest earn rate (1 tick = 1 coin) and doubled base prices (2x) compared to the current economy, since current prices are too easy. This is an intentional rebalance, not a preservation of current behavior. Existing users will notice higher prices.
+
+### Access Pattern
+
+`loadConfig()` and `saveConfig()` functions in `src/config.ts`, called at startup and from the settings menu. Config passed into overlay, shop, and rendering systems as needed.
+
+## 2. Settings Menu
+
+New "Settings" option in the main CLI menu. Submenu with four choices:
+
+1. **Color Palette** — cycle through 5 palettes with live preview name/description
+2. **Difficulty** — select earn rate tier
+3. **Price Scale** — select shop price multiplier tier
+4. **Visualizer** — select breathing visualization style
+
+Each setting uses an enquirer select prompt showing current value and available options.
+
+## 3. Color Palettes
+
+Each palette defines a set of chalk color functions used throughout the app.
+
+```typescript
+interface Palette {
+  name: string;
+  description: string;
+  primary: ChalkFunction;    // headings, titles
+  secondary: ChalkFunction;  // subheadings, labels
+  accent: ChalkFunction;     // highlights, selections
+  dim: ChalkFunction;        // muted text, borders
+  inhale: ChalkFunction;     // inhale phase color
+  exhale: ChalkFunction;     // exhale phase color
+  hold: ChalkFunction;       // hold phase color
+  bar: ChalkFunction;        // progress bar fill
+  garden: ChalkFunction;     // garden plant tint (for ASCII plants)
+}
+```
+
+### Palette Definitions
+
+- **Garden** (default): cyan primary, green exhale, yellow hold — matches current hardcoded colors exactly
+- **Ocean**: blue primary, teal exhale, steel blue hold — cool and calming
+- **Sunset**: warm orange primary, magenta exhale, amber hold — warm tones
+- **Monochrome**: white primary, gray exhale, dim hold — minimalist
+- **Aurora**: purple primary, green exhale, cyan hold — vibrant northern lights
+
+Applied globally to: breathing overlay, garden display, menu chrome, shop, progress stats, encyclopedia.
+
+## 4. Difficulty (Earn Rate)
+
+Controls how many ticks (seconds) of breathing earn one coin. Independent from price scaling.
+
+| Difficulty | Ticks per coin | Description |
+|---|---|---|
+| Chill | 1 | "A gentle pace. Coins flow freely." |
+| Normal | 5 | "Steady growth. Patience rewarded." |
+| Focused | 15 | "Deliberate progress. Each coin earned." |
+| Monk | 30 | "Deep practice. Gardens grow slowly." |
+| Ascetic | 60 | "One breath, one coin. True mastery." |
+
+Implementation: a tick counter in the breathing loop. Increment each second, award a coin when counter reaches threshold, reset counter.
+
+## 5. Price Scale
+
+Controls a multiplier applied to all shop item base prices. Independent from difficulty.
+
+| Scale | Multiplier | Description |
+|---|---|---|
+| Cheap | 1x | "Bargain garden. Everything's on sale." |
+| Normal | 2x | "Fair prices for fair flora." |
+| Expensive | 3x | "Quality costs. Choose wisely." |
+| Premium | 5x | "Luxury botanicals. Worth the wait." |
+| Luxury | 8x | "Only the most devoted gardeners." |
+
+Applied at purchase time: `effectivePrice = basePrice * multiplier`. Display the effective price in the shop. Garden expansion prices also scale.
+
+Sell values also scale proportionally: `getPlantValue()` uses the same multiplier so that the buy/sell ratio stays consistent across price scales.
+
+Note: "Normal" at 2x means base prices are doubled from the current values, addressing the current economy being too easy.
+
+## 6. Breathing Visualizers
+
+All five render in the same screen area where the progress bar currently sits. Each is a pure function:
+
+```typescript
+type Visualizer = (
+  progress: number,      // 0-1, how far into current phase
+  phase: string,         // "Inhale", "Exhale", "Hold"
+  palette: Palette,      // active color palette
+  width: number          // terminal width
+) => string[];           // lines to render
+```
+
+### 6.1 Progress Bar (default)
+
+Current `████░░░░` behavior, unchanged except it uses palette colors instead of hardcoded cyan.
+
+### 6.2 Circle
+
+Concentric ASCII circle that expands on inhale, contracts on exhale. At progress 0 it's a small dot, at progress 1 during inhale it's fully expanded. Uses characters: `·` `◦` `○` `◎` `●` for varying density. Approximately 7-9 rows tall at full expansion.
+
+Example at ~60% inhale:
+```
+      · · ·
+    ·       ·
+  ·     ●     ·
+    ·       ·
+      · · ·
+```
+
+### 6.3 Wave
+
+Horizontal sine wave drawn across the terminal width. Amplitude rises on inhale, falls on exhale. Uses characters: `~` `∼` `≈` `∿`. Multiple rows (5-7) for depth, with the wave vertically centered.
+
+Example at high amplitude:
+```
+                  ∿
+            ∼  ∿     ∿
+      ~  ∼              ∼  ~
+   ~                          ~
+∿                                ∿
+```
+
+### 6.4 Orb
+
+Radiating rings from a center point that pulse outward on inhale, contract on exhale. Uses: `✦` at center, then `*` `•` `°` `·` for outer rings. Colored with palette gradient.
+
+Example mid-pulse:
+```
+      · · ·
+    ° • * • °
+  · • ✦ ✦ ✦ • ·
+    ° • * • °
+      · · ·
+```
+
+### 6.5 Particles
+
+Characters that float upward on inhale, drift downward on exhale. A field of particles at varying heights, with positions interpolated by progress. Uses: `·` `°` `•` `✧` `✦`. Sparse distribution across ~7 rows.
+
+Example during inhale (particles rising):
+```
+    ✧       ✦
+  ·    •        ·
+      ✧    °
+  °       •    ✧
+    ·        °
+        ·
+  ·            ·
+```
+
+## 7. Exotic ASCII Plants
+
+New rarity tier "exotic" between rare and epic in the shop. These use Unicode/ASCII glyphs instead of emoji, and are colored by the active palette's `garden` color.
+
+All exotic shop items use `rarity: "exotic"`. Note: some glyphs (ꙮ, ꝏ, ᚡ, ᛝ) have limited font coverage — if they render as boxes in the user's terminal, the garden display should fall back to a simpler character like `✦`.
+
+| Name | Latin Name | Char | Base Cost | Lore |
+|---|---|---|---|---|
+| Fern Glyph | *Filix inscripta* | ❧ | 220 | "Its fronds unfurl in patterns that ancient monks used as meditation guides. Said to improve focus when planted near sitting stones." |
+| Star Moss | *Muscus stellaris* | ⍟ | 240 | "Bioluminescent moss harvested from cave ceilings. Glows faintly at night, guiding lost travelers back to their gardens." |
+| Rune Sprout | *Runicus germinus* | ᚡ | 280 | "Sprouts in the shape of old Norse runes. Druids once read fortunes in the direction of its growth." |
+| Hex Bloom | *Hexagonia flora* | ⌬ | 230 | "A crystalline flower with perfectly hexagonal petals. Mathematicians prize it; bees find it unsettling." |
+| Sigil Vine | *Vitis sigilum* | ☸ | 300 | "A twisting vine that grows in circular patterns. Tibetan gardeners train it into prayer wheels." |
+| Eye Cluster | *Oculus multiplicis* | ꙮ | 380 | "A deeply unsettling organism with multiple eye-like seed pods. Watches over the garden. Nobody asked it to." |
+| Spiral Fern | *Spiralis perpetua* | ꝏ | 260 | "Grows in a perfect logarithmic spiral. Fibonacci himself kept one on his desk, or so the story goes." |
+| Thorn Script | *Spina literata* | ᛝ | 320 | "Thorny stems that form legible text in a forgotten language. Translations are always unsettlingly personal." |
+
+Added to `const/emoji.ts` (as character mappings) and `shop/items.ts` (as purchasable items).
+
+## 8. Plant Lore & Latin Names
+
+Every existing plant (not just exotics) gets a fake latin binomial name and a 1-2 sentence lore blurb. These are stored in a new `src/const/lore.ts` file as a record keyed by plant type.
+
+```typescript
+interface PlantLore {
+  latin: string;
+  lore: string;
+}
+
+const plantLore: Record<string, PlantLore> = {
+  seedling: {
+    latin: "Germinula humilis",
+    lore: "The humblest beginning. Ancient gardeners believed planting one at dawn would bring clarity for the day ahead."
+  },
+  herb: {
+    latin: "Herba tranquilla",
+    lore: "A calming herb whose scent sharpens the mind. Tea brewed from its leaves is said to make worries feel smaller."
+  },
+  // ... all plants
+};
+```
+
+### Where Lore Appears
+
+**Shop (inline):** When highlighting an item in the shop list, the latin name and lore appear below it, similar to how breathing pattern descriptions appear in the pattern menu.
+
+```
+  ▸ 🌼 Daisy — Bellis serenium              100☀️
+    "Blooms only in gardens tended with
+     consistent breath. A symbol of patience
+     in the ancient gardening orders."
+
+    🥀 Poppy — Papaver somnialis             100☀️
+    🌵 Cactus — Cactus stoicus                120☀️
+```
+
+**Encyclopedia (dedicated view):** Shows latin name, lore, emoji/char, rarity, cost, and owned count.
+
+## 9. Garden Encyclopedia
+
+New "Encyclopedia" option in the main CLI menu. A scrollable list of all plants in the game, organized by rarity tier.
+
+### Discovered vs Undiscovered
+
+- **Discovered** (purchased at least once): shows full entry — emoji, name, latin name, lore, rarity, base cost, number owned
+- **Undiscovered** (never purchased): shows locked entry — `???` for name and lore, rarity tier visible, silhouette hint
+
+```
+╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
+  🌿  ENCYCLOPEDIA  🌿     12/35 discovered
+
+  ── Common ──
+  🌱 Seedling — Germinula humilis        ✓
+  🌿 Herb — Herba tranquilla             ✓
+  🍃 Leaves — Folia susurrens            ✓
+  🥬 Arugula — ???                        🔒
+  🍄 Mushroom — ???                       🔒
+  🪨 Rock — ???                           🔒
+
+  ── Uncommon ──
+  🌼 Daisy — Bellis serenium             ✓
+  ...
+╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
+```
+
+Selecting a discovered plant shows its full lore entry. Navigation with arrow keys, `q` to exit.
+
+### Discovery Tracking
+
+A `discovered: string[]` array added to `BreathingData` containing plant types the user has purchased at least once. Updated on purchase in the shop.
+
+## 10. Updated Plant Table (All Plants with Latin Names & Lore)
+
+### Common (base 10-25 coins)
+
+| Plant | Latin | Base Cost | Lore |
+|---|---|---|---|
+| Seedling | *Germinula humilis* | 10 | "The humblest beginning. Ancient gardeners believed planting one at dawn would bring clarity for the day ahead." |
+| Herb | *Herba tranquilla* | 20 | "A calming herb whose scent sharpens the mind. Tea brewed from its leaves is said to make worries feel smaller." |
+| Leaves | *Folia susurrens* | 20 | "These whispering leaves rustle even without wind. Monks keep them to remind themselves that stillness is never truly silent." |
+| Arugula | *Eruca amara* | 25 | "Bitter and bold. Peasant farmers chewed it before meditation, claiming the sharp taste anchored them to the present." |
+| Mushroom | *Fungus mysticus* | 25 | "Appears overnight in well-tended gardens. Its spores carry a faint scent of petrichor and forgotten dreams." |
+| Rock | *Petra immota* | 15 | "Not technically a plant. Gardeners place it as a reminder that some things need not grow to have purpose." |
+
+### Uncommon (base 50-75 coins)
+
+| Plant | Latin | Base Cost | Lore |
+|---|---|---|---|
+| Daisy | *Bellis serenium* | 50 | "Blooms only in gardens tended with consistent breath. A symbol of patience in the ancient gardening orders." |
+| Poppy | *Papaver somnialis* | 50 | "Its petals droop like heavy eyelids. Historically placed beside beds to welcome restful sleep." |
+| Cactus | *Cactus stoicus* | 60 | "Thrives on neglect. Desert philosophers admired its ability to endure long silences." |
+| Bamboo | *Bambusa rapida* | 60 | "Grows a full inch during a single breathing session. Or so they claim. Nobody has actually measured." |
+| Four Leaf Clover | *Trifolium fortunae* | 70 | "One leaf for hope, one for faith, one for love, one for breath. Finding one is said to double your next coin harvest." |
+| Maple Leaf | *Acer contemplans* | 55 | "Falls slowly and deliberately, as if demonstrating the exhale phase to anyone watching." |
+| Tomato | *Lycopersicum anxius* | 65 | "Technically a fruit. Grows redder the more you worry about whether it's a fruit or a vegetable." |
+| Tulip | *Tulipa composita* | 75 | "Opens at sunrise, closes at sunset. Dutch merchants once traded entire breathing sessions for a single bulb." |
+
+### Rare (base 120-200 coins)
+
+| Plant | Latin | Base Cost | Lore |
+|---|---|---|---|
+| Sunflower | *Helianthus devotus* | 120 | "Always faces the gardener. Some find this comforting. Others find it unnerving." |
+| Pink Rose | *Rosa spiritus* | 150 | "Petals arranged in a perfect golden spiral. Smells faintly of the last thing that made you happy." |
+| Hibiscus | *Hibiscus ignis* | 140 | "Burns a deep crimson at the center. Tropical healers prescribed staring at it for exactly four breaths." |
+| Iris | *Iris oraculum* | 130 | "Named for the messenger goddess. Said to deliver insights to gardeners who tend it during the hold phase." |
+| Marigold | *Calendula vigilans* | 160 | "Repels unwanted thoughts the way it repels unwanted insects. Effective in both cases." |
+| Evergreen | *Pinus aeternus* | 180 | "Never loses its needles. A popular gift between monks, symbolizing commitment to daily practice." |
+| Tree | *Arbor magnus* | 200 | "Takes a hundred sessions to fully appreciate. Provides shade for all the smaller plants in your garden." |
+| Palm | *Palma placida* | 175 | "Sways gently even indoors. Scientists remain baffled. Gardeners remain unbothered." |
+
+### Exotic (base 100-200 coins)
+
+(See Section 7 above for the full exotic plant table.)
+
+### Epic (base 400-600 coins)
+
+| Plant | Latin | Base Cost | Lore |
+|---|---|---|---|
+| Lotus | *Nelumbo illuminata* | 400 | "Grows from mud into perfect beauty. The central metaphor of seven different philosophical traditions, all of which claim to have noticed it first." |
+| Orchid | *Orchis enigmatica* | 450 | "Refuses to bloom on any predictable schedule. Botanists suspect it's doing this on purpose." |
+| Cherry Blossom | *Prunus ephemera* | 500 | "Blooms briefly and brilliantly. Japanese poets wrote that watching one fall teaches more about impermanence than any sutra." |
+| Bonsai | *Arbor minima disciplinae* | 600 | "A full tree compressed into a pot through years of patient trimming. A masterwork of controlled growth." |
+
+### Legendary (base 1000-3000 coins)
+
+| Plant | Latin | Base Cost | Lore |
+|---|---|---|---|
+| Dragon Fruit | *Draconis fructus* | 1000 | "Scales like a dragon, sweetness like enlightenment. Only fruits in gardens where the owner has practiced for over an hour total." |
+| Crystal Flower | *Crystallum floris* | 1500 | "Petals of pure quartz that refract light into mantras. Geologists insist it's impossible. It doesn't care." |
+| Golden Bloom | *Aurum perpetuum* | 2000 | "Radiates a warm golden light. Ancient texts claim it can only be grown by someone who has truly exhaled their worries." |
+| Ancient Tree | *Arbor antiquissima* | 3000 | "Older than the garden it's planted in. Older than the soil. Possibly older than time. Excellent shade." |
+
+## 11. File Changes Summary
+
+### New Files
+
+- `src/config.ts` — Config type, defaults, load/save, palette definitions
+- `src/visualizers.ts` — All five visualizer functions (progress-bar, circle, wave, orb, particles)
+- `src/settings.ts` — Settings menu UI using enquirer
+- `src/const/lore.ts` — Latin names and lore for all plants
+- `src/encyclopedia.ts` — Encyclopedia menu and display
+
+### Modified Files
+
+- `src/index.ts` — Add "Settings" and "Encyclopedia" to main menu routing, load config at startup
+- `src/overlay.ts` — Use config for palette, visualizer, difficulty tick counter
+- `src/breathe.ts` — Remove `performBreathing()` and `startBreathing()` (legacy code path with its own coin-earning loop that would bypass difficulty settings). Keep `getBreathingPatterns()` and `getCustomBreathingPatterns()` which are still used by `index.ts`
+- `src/storage.ts` — Add `discovered: string[]` to `BreathingData`, config persistence
+- `src/const/emoji.ts` — Add exotic ASCII plant character mappings
+- `src/shop/items.ts` — Add exotic plants with `rarity: "exotic"`, apply price scale multiplier
+- `src/shop/service.ts` — Show lore inline when highlighting items, update discovered list on purchase
+- `src/cli.ts` — Add settings and encyclopedia menu choices
+
+## 12. Migration
+
+Existing users keep their data. Missing config fields get defaults. On first load after update, if `discovered` is missing, backfill it from the user's existing `plants` array (unique plant types) so returning users see their collection in the encyclopedia. After backfill, save the updated data.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "opener": "^1.5.2"
       },
       "bin": {
-        "calm-garden-cli": "dist/index.js"
+        "calm-garden-cli": "dist/index.js",
+        "calm-garden-overlay": "dist/overlay.js"
       },
       "devDependencies": {
         "@types/node": "^22.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calm-garden-cli",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "breathing exercises in the command line",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/breathe.ts
+++ b/src/breathe.ts
@@ -1,72 +1,10 @@
-import { BreathingData, loadData, saveData } from "./storage";
-import { sleep, clearConsole } from "./utils";
 import { existsSync } from "fs";
 import { readFile } from "fs/promises";
-import { prompt } from "enquirer";
 import chalk from "chalk";
 import { breathingPatterns } from "./const/patterns";
-import { BreathingPattern, BreathingPhase } from "./types/BreathingPattern";
-import path from 'path';
+import { BreathingPattern } from "./types/BreathingPattern";
+import path from "path";
 
-async function performBreathing(
-  data: BreathingData,
-  pattern: BreathingPhase[],
-  session: {
-    time: number;
-  }
-): Promise<void> {
-  for (const phase of pattern) {
-    for (let second = 1; second <= phase.duration; second++) {
-      clearConsole();
-      console.log(`${phase.name} ${second}/${phase.duration}`);
-      console.log(`Coins: ${data.coins}`);
-      console.log(`Elapsed time: ${session.time} seconds`);
-      console.log("Press Ctrl+C to stop the breathing exercise");
-
-      await sleep(1000); // Wait for 1 second
-
-      session.time++;
-      data.totalSecondsPracticed++;
-      data.coins++;
-      await saveData(data);
-    }
-  }
-}
-
-export async function startBreathing(type: string): Promise<void> {
-  clearConsole();
-  const custom = await getCustomBreathingPatterns();
-
-  let data = await loadData();
-
-  console.log("Press Ctrl+C at any time to stop the breathing exercise.");
-
-  const selectedPattern = [...custom, ...breathingPatterns].find(
-    (p) => p.name === type
-  );
-
-  let session = { time: 0 };
-  if (selectedPattern) {
-    try {
-      while (true) {
-        await performBreathing(data, selectedPattern.pattern, session);
-      }
-    } catch (error) {
-      if (error instanceof Error && error.name === "SIGINT") {
-        console.log("\nBreathing exercise stopped.");
-      } else {
-        throw error;
-      }
-    }
-  } else {
-    const validCommands = breathingPatterns
-      .map((p) => `"${p.name}"`)
-      .join(", ");
-    console.log(
-      `Invalid breathing type. Please choose from: ${validCommands}.`
-    );
-  }
-}
 export async function getCustomBreathingPatterns(): Promise<BreathingPattern[]> {
   const filename = "breathe.json";
   const possiblePaths = [
@@ -93,10 +31,8 @@ export async function getCustomBreathingPatterns(): Promise<BreathingPattern[]> 
   return [];
 }
 
-
-export async function getBreathingPatterns(): Promise<BreathingPattern[]>{
-  const hardcoded = [...breathingPatterns]
-  const custom = await getCustomBreathingPatterns()
-  return [...hardcoded,...custom]
-
+export async function getBreathingPatterns(): Promise<BreathingPattern[]> {
+  const hardcoded = [...breathingPatterns];
+  const custom = await getCustomBreathingPatterns();
+  return [...hardcoded, ...custom];
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,8 @@ export async function setupConfig() {
       { name: "progress", message: "📊 Show Progress" },
       { name: "breathing", message: "🧘 Breathing Exercise" },
       { name: "shop", message: "🛒 Open Shop" },
+      { name: "encyclopedia", message: "📖 Encyclopedia" },
+      { name: "settings", message: "⚙️  Settings" },
       { name: "reset", message: "🔄 Reset Data" },
       { name: "exit", message: "👋 Exit" },
     ],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,8 +33,8 @@ export async function setupConfig() {
         message: `${p.emoji} ${p.display}`,
         hint: p.description!,
       })),
+      { name: "back", message: "↩ Back" },
     ];
-
 
     const breathingResponse = await prompt<{ breathingType: string }>({
       type: "select",
@@ -42,6 +42,10 @@ export async function setupConfig() {
       message: "Choose a breathing exercise:",
       choices: breathingChoices,
     });
+
+    if (breathingResponse.breathingType === "back") {
+      return { action: "back" };
+    }
 
     return { action: breathingResponse.breathingType };
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ import chalk from "chalk";
 export type PaletteName = "garden" | "ocean" | "sunset" | "monochrome" | "aurora";
 export type DifficultyName = "chill" | "normal" | "focused" | "monk" | "ascetic";
 export type PriceScaleName = "cheap" | "normal" | "expensive" | "premium" | "luxury";
-export type VisualizerName = "progress-bar" | "circle" | "wave" | "orb" | "particles";
+export type VisualizerName = "progress-bar" | "wave" | "orb";
 
 export interface Config {
   colorPalette: PaletteName;
@@ -156,9 +156,15 @@ export function getPriceMultiplier(config: Config): number {
 
 // ─── Persistence ────────────────────────────────────────────────────
 
+const validVisualizers: Set<string> = new Set(["progress-bar", "wave", "orb"]);
+
 export async function loadConfig(): Promise<Config> {
   const stored = (await storage.getItem("config")) || {};
-  return { ...defaultConfig, ...stored };
+  const config = { ...defaultConfig, ...stored };
+  if (!validVisualizers.has(config.visualizer)) {
+    config.visualizer = defaultConfig.visualizer;
+  }
+  return config;
 }
 
 export async function saveConfig(config: Config): Promise<void> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,166 @@
+import storage from "node-persist";
+import chalk from "chalk";
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export type PaletteName = "garden" | "ocean" | "sunset" | "monochrome" | "aurora";
+export type DifficultyName = "chill" | "normal" | "focused" | "monk" | "ascetic";
+export type PriceScaleName = "cheap" | "normal" | "expensive" | "premium" | "luxury";
+export type VisualizerName = "progress-bar" | "circle" | "wave" | "orb" | "particles";
+
+export interface Config {
+  colorPalette: PaletteName;
+  difficulty: DifficultyName;
+  priceScale: PriceScaleName;
+  visualizer: VisualizerName;
+}
+
+export interface Palette {
+  name: string;
+  description: string;
+  primary: chalk.Chalk;
+  secondary: chalk.Chalk;
+  accent: chalk.Chalk;
+  dim: chalk.Chalk;
+  inhale: chalk.Chalk;
+  exhale: chalk.Chalk;
+  hold: chalk.Chalk;
+  bar: chalk.Chalk;
+  garden: chalk.Chalk;
+}
+
+export interface DifficultyTier {
+  name: DifficultyName;
+  ticksPerCoin: number;
+  description: string;
+}
+
+export interface PriceScaleTier {
+  name: PriceScaleName;
+  multiplier: number;
+  description: string;
+}
+
+// ─── Defaults ───────────────────────────────────────────────────────
+
+export const defaultConfig: Config = {
+  colorPalette: "garden",
+  difficulty: "chill",
+  priceScale: "normal",
+  visualizer: "progress-bar",
+};
+
+// ─── Palettes ───────────────────────────────────────────────────────
+
+export const palettes: Record<PaletteName, Palette> = {
+  garden: {
+    name: "Garden",
+    description: "Lush greens and earthy tones",
+    primary: chalk.cyan.bold,
+    secondary: chalk.green,
+    accent: chalk.cyan,
+    dim: chalk.dim,
+    inhale: chalk.cyan.bold,
+    exhale: chalk.green.bold,
+    hold: chalk.yellow.bold,
+    bar: chalk.cyan,
+    garden: chalk.green,
+  },
+  ocean: {
+    name: "Ocean",
+    description: "Cool blues and deep teals",
+    primary: chalk.blue.bold,
+    secondary: chalk.blueBright,
+    accent: chalk.cyanBright,
+    dim: chalk.dim,
+    inhale: chalk.cyanBright.bold,
+    exhale: chalk.blue.bold,
+    hold: chalk.blueBright.bold,
+    bar: chalk.blue,
+    garden: chalk.cyanBright,
+  },
+  sunset: {
+    name: "Sunset",
+    description: "Warm oranges and soft magentas",
+    primary: chalk.hex("#FF6B35").bold,
+    secondary: chalk.yellow,
+    accent: chalk.magenta,
+    dim: chalk.dim,
+    inhale: chalk.hex("#FF6B35").bold,
+    exhale: chalk.magenta.bold,
+    hold: chalk.yellow.bold,
+    bar: chalk.hex("#FF6B35"),
+    garden: chalk.yellow,
+  },
+  monochrome: {
+    name: "Monochrome",
+    description: "Clean whites and soft grays",
+    primary: chalk.white.bold,
+    secondary: chalk.gray,
+    accent: chalk.whiteBright,
+    dim: chalk.dim,
+    inhale: chalk.white.bold,
+    exhale: chalk.gray.bold,
+    hold: chalk.whiteBright.bold,
+    bar: chalk.white,
+    garden: chalk.whiteBright,
+  },
+  aurora: {
+    name: "Aurora",
+    description: "Vivid purples and northern greens",
+    primary: chalk.magenta.bold,
+    secondary: chalk.green,
+    accent: chalk.cyan,
+    dim: chalk.dim,
+    inhale: chalk.magenta.bold,
+    exhale: chalk.green.bold,
+    hold: chalk.cyan.bold,
+    bar: chalk.magenta,
+    garden: chalk.greenBright,
+  },
+};
+
+// ─── Difficulty tiers ───────────────────────────────────────────────
+
+export const difficultyTiers: DifficultyTier[] = [
+  { name: "chill", ticksPerCoin: 1, description: "A gentle pace. Coins flow freely." },
+  { name: "normal", ticksPerCoin: 5, description: "Steady growth. Patience rewarded." },
+  { name: "focused", ticksPerCoin: 15, description: "Deliberate progress. Each coin earned." },
+  { name: "monk", ticksPerCoin: 30, description: "Deep practice. Gardens grow slowly." },
+  { name: "ascetic", ticksPerCoin: 60, description: "One breath, one coin. True mastery." },
+];
+
+// ─── Price scale tiers ──────────────────────────────────────────────
+
+export const priceScaleTiers: PriceScaleTier[] = [
+  { name: "cheap", multiplier: 1, description: "Bargain garden. Everything's on sale." },
+  { name: "normal", multiplier: 2, description: "Fair prices for fair flora." },
+  { name: "expensive", multiplier: 3, description: "Quality costs. Choose wisely." },
+  { name: "premium", multiplier: 5, description: "Luxury botanicals. Worth the wait." },
+  { name: "luxury", multiplier: 8, description: "Only the most devoted gardeners." },
+];
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+export function getPalette(config: Config): Palette {
+  return palettes[config.colorPalette];
+}
+
+export function getDifficultyTier(config: Config): DifficultyTier {
+  return difficultyTiers.find((t) => t.name === config.difficulty)!;
+}
+
+export function getPriceMultiplier(config: Config): number {
+  return priceScaleTiers.find((t) => t.name === config.priceScale)!.multiplier;
+}
+
+// ─── Persistence ────────────────────────────────────────────────────
+
+export async function loadConfig(): Promise<Config> {
+  const stored = (await storage.getItem("config")) || {};
+  return { ...defaultConfig, ...stored };
+}
+
+export async function saveConfig(config: Config): Promise<void> {
+  await storage.setItem("config", config);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ import chalk from "chalk";
 export type PaletteName = "garden" | "ocean" | "sunset" | "monochrome" | "aurora";
 export type DifficultyName = "chill" | "normal" | "focused" | "monk" | "ascetic";
 export type PriceScaleName = "cheap" | "normal" | "expensive" | "premium" | "luxury";
-export type VisualizerName = "progress-bar" | "wave" | "orb";
+export type VisualizerName = "progress-bar" | "wave" | "orb" | "lotus";
 
 export interface Config {
   colorPalette: PaletteName;
@@ -156,7 +156,7 @@ export function getPriceMultiplier(config: Config): number {
 
 // ─── Persistence ────────────────────────────────────────────────────
 
-const validVisualizers: Set<string> = new Set(["progress-bar", "wave", "orb"]);
+const validVisualizers: Set<string> = new Set(["progress-bar", "wave", "orb", "lotus"]);
 
 export async function loadConfig(): Promise<Config> {
   const stored = (await storage.getItem("config")) || {};

--- a/src/const/emoji.ts
+++ b/src/const/emoji.ts
@@ -38,6 +38,16 @@ export const plantEmojis = {
   "crystal-flower": "💎",
   "golden-bloom": "🌟",
   "ancient-tree": "🏯",
+
+  // Exotic (ASCII/Unicode glyphs)
+  "fern-glyph": "❧",
+  "star-moss": "⍟",
+  "rune-sprout": "ᚡ",
+  "hex-bloom": "⌬",
+  "sigil-vine": "☸",
+  "eye-cluster": "ꙮ",
+  "spiral-fern": "ꝏ",
+  "thorn-script": "ᛝ",
 } as const;
 
 export const emojis = {

--- a/src/const/emoji.ts
+++ b/src/const/emoji.ts
@@ -54,6 +54,7 @@ export const emojis = {
   expansion: "🔍",
   shuffle: "🔀",
   sell: "💰",
+  trade: "🔄",
   ...plantEmojis,
 } as const;
 

--- a/src/const/emoji.ts
+++ b/src/const/emoji.ts
@@ -1,33 +1,46 @@
 export const plantEmojis = {
-  arugula: "🥬",
-  daisy: "🌼",
-  iris: "🪻",
-  lotus: "🪷",
-  marigold: "🏵️",
-  "pink-rose": "🌹",
-  poppy: "🥀",
-  sunflower: "🌻",
-  tomato: "🍅",
-  tree: "🌳",
-  cactus: "🌵",
-  palm: "🌴",
-  bonsai: "🎍",
-  bamboo: "🎋",
-  hibiscus: "🌺",
-  orchid: "🌷",
-  "cherry-blossom": "🌸",
-  mushroom: "🍄",
-  herb: "🌿",
+  // Common (cheap)
   seedling: "🌱",
+  herb: "🌿",
   leaves: "🍃",
+  arugula: "🥬",
+  mushroom: "🍄",
+  rock: "🪨",
+
+  // Uncommon
+  daisy: "🌼",
+  poppy: "🥀",
+  cactus: "🌵",
+  bamboo: "🎋",
   "four-leaf-clover": "🍀",
   "maple-leaf": "🍁",
+  tomato: "🍅",
+  tulip: "🌷",
+
+  // Rare
+  sunflower: "🌻",
+  "pink-rose": "🌹",
+  hibiscus: "🌺",
+  iris: "🪻",
+  marigold: "🏵️",
   evergreen: "🌲",
-  rock: "🪨",
+  tree: "🌳",
+  palm: "🌴",
+
+  // Epic
+  lotus: "🪷",
+  orchid: "🪻",
+  "cherry-blossom": "🌸",
+  bonsai: "🎍",
+
+  // Legendary
+  "dragon-fruit": "🐉",
+  "crystal-flower": "💎",
+  "golden-bloom": "🌟",
+  "ancient-tree": "🏯",
 } as const;
 
 export const emojis = {
-  // Add more plant types and their corresponding emojis as needed
   expansion: "🔍",
   shuffle: "🔀",
   sell: "💰",

--- a/src/const/lore.ts
+++ b/src/const/lore.ts
@@ -1,0 +1,170 @@
+export interface PlantLore {
+  latin: string;
+  lore: string;
+}
+
+export const plantLore: Record<string, PlantLore> = {
+  // ── Common ──
+  seedling: {
+    latin: "Germinula humilis",
+    lore: "The humblest beginning. Ancient gardeners believed planting one at dawn would bring clarity for the day ahead.",
+  },
+  herb: {
+    latin: "Herba tranquilla",
+    lore: "A calming herb whose scent sharpens the mind. Tea brewed from its leaves is said to make worries feel smaller.",
+  },
+  leaves: {
+    latin: "Folia susurrens",
+    lore: "These whispering leaves rustle even without wind. Monks keep them to remind themselves that stillness is never truly silent.",
+  },
+  arugula: {
+    latin: "Eruca amara",
+    lore: "Bitter and bold. Peasant farmers chewed it before meditation, claiming the sharp taste anchored them to the present.",
+  },
+  mushroom: {
+    latin: "Fungus mysticus",
+    lore: "Appears overnight in well-tended gardens. Its spores carry a faint scent of petrichor and forgotten dreams.",
+  },
+  rock: {
+    latin: "Petra immota",
+    lore: "Not technically a plant. Gardeners place it as a reminder that some things need not grow to have purpose.",
+  },
+
+  // ── Uncommon ──
+  daisy: {
+    latin: "Bellis serenium",
+    lore: "Blooms only in gardens tended with consistent breath. A symbol of patience in the ancient gardening orders.",
+  },
+  poppy: {
+    latin: "Papaver somnialis",
+    lore: "Its petals droop like heavy eyelids. Historically placed beside beds to welcome restful sleep.",
+  },
+  cactus: {
+    latin: "Cactus stoicus",
+    lore: "Thrives on neglect. Desert philosophers admired its ability to endure long silences.",
+  },
+  bamboo: {
+    latin: "Bambusa rapida",
+    lore: "Grows a full inch during a single breathing session. Or so they claim. Nobody has actually measured.",
+  },
+  "four-leaf-clover": {
+    latin: "Trifolium fortunae",
+    lore: "One leaf for hope, one for faith, one for love, one for breath. Finding one is said to double your next coin harvest.",
+  },
+  "maple-leaf": {
+    latin: "Acer contemplans",
+    lore: "Falls slowly and deliberately, as if demonstrating the exhale phase to anyone watching.",
+  },
+  tomato: {
+    latin: "Lycopersicum anxius",
+    lore: "Technically a fruit. Grows redder the more you worry about whether it's a fruit or a vegetable.",
+  },
+  tulip: {
+    latin: "Tulipa composita",
+    lore: "Opens at sunrise, closes at sunset. Dutch merchants once traded entire breathing sessions for a single bulb.",
+  },
+
+  // ── Rare ──
+  sunflower: {
+    latin: "Helianthus devotus",
+    lore: "Always faces the gardener. Some find this comforting. Others find it unnerving.",
+  },
+  "pink-rose": {
+    latin: "Rosa spiritus",
+    lore: "Petals arranged in a perfect golden spiral. Smells faintly of the last thing that made you happy.",
+  },
+  hibiscus: {
+    latin: "Hibiscus ignis",
+    lore: "Burns a deep crimson at the center. Tropical healers prescribed staring at it for exactly four breaths.",
+  },
+  iris: {
+    latin: "Iris oraculum",
+    lore: "Named for the messenger goddess. Said to deliver insights to gardeners who tend it during the hold phase.",
+  },
+  marigold: {
+    latin: "Calendula vigilans",
+    lore: "Repels unwanted thoughts the way it repels unwanted insects. Effective in both cases.",
+  },
+  evergreen: {
+    latin: "Pinus aeternus",
+    lore: "Never loses its needles. A popular gift between monks, symbolizing commitment to daily practice.",
+  },
+  tree: {
+    latin: "Arbor magnus",
+    lore: "Takes a hundred sessions to fully appreciate. Provides shade for all the smaller plants in your garden.",
+  },
+  palm: {
+    latin: "Palma placida",
+    lore: "Sways gently even indoors. Scientists remain baffled. Gardeners remain unbothered.",
+  },
+
+  // ── Exotic ──
+  "fern-glyph": {
+    latin: "Filix inscripta",
+    lore: "Its fronds unfurl in patterns that ancient monks used as meditation guides. Said to improve focus when planted near sitting stones.",
+  },
+  "star-moss": {
+    latin: "Muscus stellaris",
+    lore: "Bioluminescent moss harvested from cave ceilings. Glows faintly at night, guiding lost travelers back to their gardens.",
+  },
+  "rune-sprout": {
+    latin: "Runicus germinus",
+    lore: "Sprouts in the shape of old Norse runes. Druids once read fortunes in the direction of its growth.",
+  },
+  "hex-bloom": {
+    latin: "Hexagonia flora",
+    lore: "A crystalline flower with perfectly hexagonal petals. Mathematicians prize it; bees find it unsettling.",
+  },
+  "sigil-vine": {
+    latin: "Vitis sigilum",
+    lore: "A twisting vine that grows in circular patterns. Tibetan gardeners train it into prayer wheels.",
+  },
+  "eye-cluster": {
+    latin: "Oculus multiplicis",
+    lore: "A deeply unsettling organism with multiple eye-like seed pods. Watches over the garden. Nobody asked it to.",
+  },
+  "spiral-fern": {
+    latin: "Spiralis perpetua",
+    lore: "Grows in a perfect logarithmic spiral. Fibonacci himself kept one on his desk, or so the story goes.",
+  },
+  "thorn-script": {
+    latin: "Spina literata",
+    lore: "Thorny stems that form legible text in a forgotten language. Translations are always unsettlingly personal.",
+  },
+
+  // ── Epic ──
+  lotus: {
+    latin: "Nelumbo illuminata",
+    lore: "Grows from mud into perfect beauty. The central metaphor of seven different philosophical traditions, all of which claim to have noticed it first.",
+  },
+  orchid: {
+    latin: "Orchis enigmatica",
+    lore: "Refuses to bloom on any predictable schedule. Botanists suspect it's doing this on purpose.",
+  },
+  "cherry-blossom": {
+    latin: "Prunus ephemera",
+    lore: "Blooms briefly and brilliantly. Japanese poets wrote that watching one fall teaches more about impermanence than any sutra.",
+  },
+  bonsai: {
+    latin: "Arbor minima disciplinae",
+    lore: "A full tree compressed into a pot through years of patient trimming. A masterwork of controlled growth.",
+  },
+
+  // ── Legendary ──
+  "dragon-fruit": {
+    latin: "Draconis fructus",
+    lore: "Scales like a dragon, sweetness like enlightenment. Only fruits in gardens where the owner has practiced for over an hour total.",
+  },
+  "crystal-flower": {
+    latin: "Crystallum floris",
+    lore: "Petals of pure quartz that refract light into mantras. Geologists insist it's impossible. It doesn't care.",
+  },
+  "golden-bloom": {
+    latin: "Aurum perpetuum",
+    lore: "Radiates a warm golden light. Ancient texts claim it can only be grown by someone who has truly exhaled their worries.",
+  },
+  "ancient-tree": {
+    latin: "Arbor antiquissima",
+    lore: "Older than the garden it's planted in. Older than the soil. Possibly older than time. Excellent shade.",
+  },
+};

--- a/src/encyclopedia.ts
+++ b/src/encyclopedia.ts
@@ -1,0 +1,101 @@
+import { prompt } from "enquirer";
+import { loadData, BreathingData } from "./storage";
+import { shopItems } from "./shop/items";
+import { plantLore } from "./const/lore";
+import { emojis, EmojiKey } from "./const/emoji";
+import { Config, getPalette } from "./config";
+import { clearConsole } from "./utils";
+
+const rarityOrder = ["common", "uncommon", "rare", "exotic", "epic", "legendary"];
+
+export async function showEncyclopedia(config: Config): Promise<void> {
+  const data = await loadData();
+  const palette = getPalette(config);
+
+  const plants = shopItems.filter((item) => item.rarity);
+  const discovered = new Set(data.discovered || []);
+  const totalDiscovered = plants.filter((p) => discovered.has(p.type)).length;
+
+  clearConsole();
+  console.log(palette.primary(`\n🌿  ENCYCLOPEDIA  🌿     ${totalDiscovered}/${plants.length} discovered\n`));
+
+  const grouped: Record<string, typeof plants> = {};
+  for (const plant of plants) {
+    const rarity = plant.rarity || "common";
+    if (!grouped[rarity]) grouped[rarity] = [];
+    grouped[rarity].push(plant);
+  }
+
+  const choices: Array<{ name: string; message: string; hint?: string }> = [];
+
+  for (const rarity of rarityOrder) {
+    if (!grouped[rarity]) continue;
+
+    for (const plant of grouped[rarity]) {
+      const isDiscovered = discovered.has(plant.type);
+      const emoji = emojis[plant.type as EmojiKey] || "?";
+      const lore = plantLore[plant.type];
+      const ownedCount = data.plants.filter((p: { type: string }) => p.type === plant.type).length;
+
+      if (isDiscovered) {
+        choices.push({
+          name: plant.type,
+          message: `${emoji} ${plant.name} — ${lore?.latin || "???"}`,
+          hint: ownedCount > 0 ? ` (owned: ${ownedCount})` : " ✓",
+        });
+      } else {
+        choices.push({
+          name: `locked-${plant.type}`,
+          message: palette.dim(`🔒 ??? — ???`),
+          hint: ` [${rarity}]`,
+        });
+      }
+    }
+  }
+
+  choices.push({ name: "back", message: "↩ Back" });
+
+  const response = await prompt<{ plant: string }>({
+    type: "select",
+    name: "plant",
+    message: "Select a plant to view details:",
+    choices,
+  });
+
+  if (response.plant === "back" || response.plant.startsWith("locked-")) return;
+
+  if (discovered.has(response.plant)) {
+    await showPlantDetail(response.plant, data, config);
+  }
+}
+
+async function showPlantDetail(
+  plantType: string,
+  data: BreathingData,
+  config: Config
+): Promise<void> {
+  const palette = getPalette(config);
+  const lore = plantLore[plantType];
+  const item = shopItems.find((i) => i.type === plantType);
+  const emoji = emojis[plantType as EmojiKey] || "?";
+  const ownedCount = data.plants.filter((p: { type: string }) => p.type === plantType).length;
+
+  clearConsole();
+  console.log("");
+  console.log(palette.primary(`  ${emoji}  ${item?.name || plantType}`));
+  console.log(palette.accent(`  ${lore?.latin || "Unknown species"}`));
+  console.log("");
+  console.log(palette.dim(`  Rarity: ${item?.rarity || "unknown"}`));
+  console.log(palette.dim(`  Base cost: ${item?.cost || "?"} coins`));
+  console.log(palette.dim(`  Owned: ${ownedCount}`));
+  console.log("");
+  console.log(`  "${lore?.lore || "No information available."}"`);
+  console.log("");
+
+  await prompt<{ action: string }>({
+    type: "select",
+    name: "action",
+    message: "",
+    choices: [{ name: "back", message: "↩ Back" }],
+  });
+}

--- a/src/garden.ts
+++ b/src/garden.ts
@@ -1,3 +1,4 @@
+import { prompt } from "enquirer";
 import { EmojiKey, emojis } from "./const/emoji";
 import { loadData } from "./storage";
 import { clearConsole } from "./utils";
@@ -14,12 +15,19 @@ export async function showGarden(): Promise<void> {
     for (let x = 0; x < data.gardenSize; x++) {
       const plant = data.plants.find((p) => p.x === x && p.y === y);
       if (plant) {
-        row += emojis[plant.type as EmojiKey] || "🌱"; // Default to seedling if type not found
+        row += emojis[plant.type as EmojiKey] || "🌱";
       } else {
-        row += emptyPlotEmoji; // Empty plot
+        row += emptyPlotEmoji;
       }
     }
     console.log(row);
   }
 
+  console.log("");
+  await prompt<{ action: string }>({
+    type: "select",
+    name: "action",
+    message: "",
+    choices: [{ name: "back", message: "↩ Back" }],
+  });
 }

--- a/src/garden.ts
+++ b/src/garden.ts
@@ -1,26 +1,51 @@
 import { prompt } from "enquirer";
+import chalk from "chalk";
 import { EmojiKey, emojis } from "./const/emoji";
 import { loadData } from "./storage";
 import { clearConsole } from "./utils";
 
-const emptyPlotEmoji = "🌱"; // Grass emoji for empty plots
+export const EMPTY_PLOT = chalk.green("··");
+
+export function renderGardenGrid(
+  plants: { x: number; y: number; type: string }[],
+  gardenSize: number,
+  showCoords = false
+): string[] {
+  const lines: string[] = [];
+
+  if (showCoords) {
+    let header = "   ";
+    for (let x = 0; x < gardenSize; x++) {
+      header += ` ${x} `;
+    }
+    lines.push(chalk.dim(header));
+  }
+
+  for (let y = 0; y < gardenSize; y++) {
+    let row = showCoords ? chalk.dim(` ${y} `) : "";
+    for (let x = 0; x < gardenSize; x++) {
+      const plant = plants.find((p) => p.x === x && p.y === y);
+      if (plant) {
+        row += (emojis[plant.type as EmojiKey] || EMPTY_PLOT) + " ";
+      } else {
+        row += EMPTY_PLOT + " ";
+      }
+    }
+    lines.push(row);
+  }
+
+  return lines;
+}
+
 export async function showGarden(): Promise<void> {
   clearConsole();
   let data = await loadData();
 
   console.log("Your Garden:\n");
 
-  for (let y = 0; y < data.gardenSize; y++) {
-    let row = "";
-    for (let x = 0; x < data.gardenSize; x++) {
-      const plant = data.plants.find((p) => p.x === x && p.y === y);
-      if (plant) {
-        row += emojis[plant.type as EmojiKey] || "🌱";
-      } else {
-        row += emptyPlotEmoji;
-      }
-    }
-    console.log(row);
+  const lines = renderGardenGrid(data.plants, data.gardenSize, true);
+  for (const line of lines) {
+    console.log(line);
   }
 
   console.log("");

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@
 import { setupConfig } from "./cli";
 import { showGarden } from "./garden";
 import { showProgress } from "./progress";
-import { getBreathingPatterns, startBreathing } from "./breathe";
+import { getBreathingPatterns } from "./breathe";
+import { startBreathingOverlay } from "./overlay";
 import { showShop } from "./shop/service";
 import { initStorage, resetData } from "./storage";
 
@@ -15,7 +16,7 @@ async function main() {
     const { action } = await setupConfig();
 
     if (patternSet.has(action)) {
-      await startBreathing(action);
+      await startBreathingOverlay(action);
       continue;
     }
 
@@ -33,7 +34,7 @@ async function main() {
         await resetData();
         break;
       case "exit":
-        console.log("Thank you for using CLI Box Breathing App!");
+        console.log("Thank you for using CLI Calm Garden!");
         return;
       default:
         console.log("Invalid option. Please try again.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,14 @@ import { showProgress } from "./progress";
 import { getBreathingPatterns } from "./breathe";
 import { startBreathingOverlay } from "./overlay";
 import { showShop } from "./shop/service";
+import { showSettings } from "./settings";
+import { showEncyclopedia } from "./encyclopedia";
+import { loadConfig } from "./config";
 import { initStorage, resetData } from "./storage";
 
 async function main() {
   await initStorage();
+  let config = await loadConfig();
 
   const patterns = await getBreathingPatterns();
   const patternSet = new Set(patterns.map((p) => p.name));
@@ -16,7 +20,8 @@ async function main() {
     const { action } = await setupConfig();
 
     if (patternSet.has(action)) {
-      await startBreathingOverlay(action);
+      config = await loadConfig();
+      await startBreathingOverlay(action, config);
       continue;
     }
 
@@ -28,7 +33,16 @@ async function main() {
         await showProgress();
         break;
       case "shop":
-        await showShop();
+        config = await loadConfig();
+        await showShop(config);
+        break;
+      case "encyclopedia":
+        config = await loadConfig();
+        await showEncyclopedia(config);
+        break;
+      case "settings":
+        config = await loadConfig();
+        await showSettings(config);
         break;
       case "reset":
         await resetData();

--- a/src/overlay.ts
+++ b/src/overlay.ts
@@ -83,8 +83,22 @@ function render(): void {
 
   lines.push("");
 
-  const progress =
+  const rawProgress =
     currentPhaseDuration > 0 ? currentPhaseSecond / currentPhaseDuration : 0;
+
+  // Compute effective progress so visualizers breathe in AND out
+  let progress: number;
+  if (currentPhaseName === "Inhale") {
+    progress = rawProgress;
+  } else if (currentPhaseName === "Exhale") {
+    progress = 1 - rawProgress;
+  } else {
+    // Hold: check previous phase to determine level
+    const prevIndex = (phaseIndex - 1 + activePhases.length) % activePhases.length;
+    const prevPhase = activePhases[prevIndex].name;
+    progress = prevPhase === "Exhale" ? 0 : 1;
+  }
+
   const vizLines = visualizers[config.visualizer](
     progress,
     currentPhaseName,

--- a/src/overlay.ts
+++ b/src/overlay.ts
@@ -1,0 +1,327 @@
+import chalk from "chalk";
+import { breathingPatterns } from "./const/patterns";
+import { BreathingPhase } from "./types/BreathingPattern";
+import { emojis, EmojiKey } from "./const/emoji";
+import { loadData, saveData, BreathingData } from "./storage";
+
+// ─── State ───────────────────────────────────────────────────────────
+
+let paused = false;
+let running = true;
+let data: BreathingData;
+let sessionTime = 0;
+let currentPhaseName = "";
+let currentPhaseSecond = 0;
+let currentPhaseDuration = 0;
+let patternName = "";
+let activePhases: BreathingPhase[] = [];
+let phaseIndex = 0;
+let menuOpen = false;
+let menuIndex = 0;
+
+let inputCleanup: (() => void) | null = null;
+
+// ─── Terminal helpers ────────────────────────────────────────────────
+
+function hideCursor(): void {
+  process.stdout.write("\x1B[?25l");
+}
+
+function showCursor(): void {
+  process.stdout.write("\x1B[?25h");
+}
+
+function moveTo(row: number, col: number): void {
+  process.stdout.write(`\x1B[${row};${col}H`);
+}
+
+function clearScreen(): void {
+  process.stdout.write("\x1B[2J");
+}
+
+function getTermWidth(): number {
+  return process.stdout.columns || 60;
+}
+
+function center(text: string, width: number): string {
+  const stripped = text.replace(/\x1B\[[0-9;]*m/g, "");
+  const pad = Math.max(0, Math.floor((width - stripped.length) / 2));
+  return " ".repeat(pad) + text;
+}
+
+// ─── Render ──────────────────────────────────────────────────────────
+
+function render(): void {
+  const w = getTermWidth();
+
+  clearScreen();
+  moveTo(1, 1);
+
+  const lines: string[] = [];
+
+  lines.push("");
+  lines.push(center(chalk.bold("🌿  calm garden  🌿"), w));
+  lines.push(center(chalk.dim(patternName), w));
+  lines.push("");
+
+  if (paused) {
+    lines.push(center(chalk.yellow.bold("⏸  PAUSED"), w));
+  } else {
+    const phaseColor =
+      currentPhaseName === "Inhale"
+        ? chalk.cyan.bold
+        : currentPhaseName === "Exhale"
+        ? chalk.green.bold
+        : chalk.yellow.bold;
+    lines.push(center(phaseColor(`${currentPhaseName}`), w));
+  }
+
+  lines.push("");
+
+  const barWidth = Math.min(30, w - 10);
+  const progress =
+    currentPhaseDuration > 0 ? currentPhaseSecond / currentPhaseDuration : 0;
+  const filled = Math.round(progress * barWidth);
+  const bar =
+    chalk.cyan("█".repeat(filled)) +
+    chalk.dim("░".repeat(barWidth - filled));
+  lines.push(center(bar, w));
+  lines.push(
+    center(chalk.dim(`${currentPhaseSecond}/${currentPhaseDuration}s`), w)
+  );
+
+  lines.push("");
+
+  // Garden
+  const gardenSize = data.gardenSize;
+  const emptyPlot = "🌱";
+  for (let y = 0; y < gardenSize; y++) {
+    let row = "";
+    for (let x = 0; x < gardenSize; x++) {
+      const plant = data.plants.find(
+        (p: { x: number; y: number; type: string }) => p.x === x && p.y === y
+      );
+      row += plant
+        ? emojis[plant.type as EmojiKey] || emptyPlot
+        : emptyPlot;
+    }
+    lines.push(center(row, w));
+  }
+
+  lines.push("");
+
+  lines.push(
+    center(
+      chalk.dim(`☀️ ${data.coins}`) +
+        chalk.dim("  ⏱ ") +
+        chalk.dim(formatTime(sessionTime)),
+      w
+    )
+  );
+
+  lines.push("");
+
+  lines.push(
+    center(
+      chalk.dim("[space] pause/resume  [m] menu  [q] back"),
+      w
+    )
+  );
+
+  process.stdout.write(lines.join("\n"));
+}
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+
+// ─── Menu ────────────────────────────────────────────────────────────
+
+function showMenu(): void {
+  if (menuOpen) {
+    menuOpen = false;
+    paused = false;
+    render();
+    return;
+  }
+  menuOpen = true;
+  paused = true;
+  menuIndex = 0;
+  renderMenu();
+}
+
+function renderMenu(): void {
+  const w = getTermWidth();
+  clearScreen();
+  moveTo(1, 1);
+
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(center(chalk.bold("🌿  select pattern  🌿"), w));
+  lines.push("");
+
+  for (let i = 0; i < breathingPatterns.length; i++) {
+    const p = breathingPatterns[i];
+    const selected = i === menuIndex;
+    const prefix = selected ? chalk.cyan.bold("▸ ") : "  ";
+    const text = selected
+      ? chalk.cyan.bold(`${p.emoji} ${p.display}`)
+      : chalk.dim(`${p.emoji} ${p.display}`);
+    lines.push(center(prefix + text, w));
+    lines.push(center(chalk.dim(`  ${p.description}`), w));
+    lines.push("");
+  }
+
+  lines.push(
+    center(chalk.dim("[↑↓] select  [enter] start  [m] back"), w)
+  );
+
+  process.stdout.write(lines.join("\n"));
+}
+
+function handleMenuInput(key: string): void {
+  if (key === "\x1B[A" || key === "k") {
+    menuIndex =
+      (menuIndex - 1 + breathingPatterns.length) % breathingPatterns.length;
+    renderMenu();
+  } else if (key === "\x1B[B" || key === "j") {
+    menuIndex = (menuIndex + 1) % breathingPatterns.length;
+    renderMenu();
+  } else if (key === "\r") {
+    const selected = breathingPatterns[menuIndex];
+    patternName = selected.display;
+    activePhases = selected.pattern;
+    currentPhaseName = activePhases[0].name;
+    currentPhaseDuration = activePhases[0].duration;
+    currentPhaseSecond = 0;
+    phaseIndex = 0;
+    menuOpen = false;
+    paused = false;
+    render();
+  } else if (key === "m" || key === "q" || key === "\x1B") {
+    menuOpen = false;
+    paused = false;
+    render();
+  }
+}
+
+// ─── Input ───────────────────────────────────────────────────────────
+
+function setupInput(): void {
+  if (!process.stdin.isTTY) return;
+  process.stdin.setRawMode(true);
+  process.stdin.resume();
+  process.stdin.setEncoding("utf8");
+
+  const handler = (key: string) => {
+    if (menuOpen) {
+      handleMenuInput(key);
+      return;
+    }
+    if (key === " ") {
+      paused = !paused;
+      render();
+    } else if (key === "m") {
+      showMenu();
+    } else if (key === "q" || key === "\x03") {
+      running = false;
+    }
+  };
+
+  process.stdin.on("data", handler);
+
+  inputCleanup = () => {
+    process.stdin.removeListener("data", handler);
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(false);
+    }
+    process.stdin.pause();
+  };
+}
+
+// ─── Breathing loop ──────────────────────────────────────────────────
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function breatheLoop(): Promise<void> {
+  while (running) {
+    phaseIndex = 0;
+    while (phaseIndex < activePhases.length && running) {
+      const phase = activePhases[phaseIndex];
+      currentPhaseName = phase.name;
+      currentPhaseDuration = phase.duration;
+
+      for (let s = 1; s <= phase.duration; s++) {
+        if (!running) return;
+
+        while ((paused || menuOpen) && running) {
+          await sleep(100);
+        }
+        if (!running) return;
+
+        currentPhaseSecond = s;
+        render();
+
+        await sleep(1000);
+
+        sessionTime++;
+        data.totalSecondsPracticed++;
+        data.coins++;
+        await saveData(data);
+      }
+
+      phaseIndex++;
+    }
+  }
+}
+
+// ─── Exported entry point ────────────────────────────────────────────
+
+export async function startBreathingOverlay(
+  patternType: string
+): Promise<void> {
+  // Reset state for each session
+  paused = false;
+  running = true;
+  sessionTime = 0;
+  menuOpen = false;
+  menuIndex = 0;
+
+  data = await loadData();
+
+  const match = breathingPatterns.find((p) => p.name === patternType);
+  if (!match) {
+    console.log(`Unknown pattern: ${patternType}`);
+    return;
+  }
+
+  patternName = match.display;
+  activePhases = match.pattern;
+  currentPhaseName = activePhases[0].name;
+  currentPhaseDuration = activePhases[0].duration;
+  currentPhaseSecond = 0;
+
+  hideCursor();
+  setupInput();
+  render();
+
+  await breatheLoop();
+
+  // Cleanup when loop exits (user pressed q)
+  if (inputCleanup) inputCleanup();
+  showCursor();
+  clearScreen();
+  moveTo(1, 1);
+
+  if (sessionTime > 0) {
+    console.log(
+      chalk.green(
+        `Session done. ${sessionTime}s practiced, ${sessionTime} coins earned.\n`
+      )
+    );
+  }
+}

--- a/src/overlay.ts
+++ b/src/overlay.ts
@@ -5,6 +5,7 @@ import { emojis, EmojiKey } from "./const/emoji";
 import { loadData, saveData, BreathingData } from "./storage";
 import { Config, getPalette, getDifficultyTier, Palette } from "./config";
 import { visualizers } from "./visualizers";
+import { EMPTY_PLOT } from "./garden";
 
 // ─── State ───────────────────────────────────────────────────────────
 
@@ -116,7 +117,7 @@ function render(): void {
 
   // Garden
   const gardenSize = data.gardenSize;
-  const emptyPlot = "🌱";
+  const emptyPlot = EMPTY_PLOT;
   const chalkColors: Record<string, chalk.Chalk> = {
     red: chalk.red,
     green: chalk.green,

--- a/src/overlay.ts
+++ b/src/overlay.ts
@@ -335,9 +335,11 @@ export async function startBreathingOverlay(
   moveTo(1, 1);
 
   if (sessionTime > 0) {
+    const tier = getDifficultyTier(config);
+    const coinsEarned = Math.floor(sessionTime / tier.ticksPerCoin);
     console.log(
-      chalk.green(
-        `Session done. ${sessionTime}s practiced, ${sessionTime} coins earned.\n`
+      palette.secondary(
+        `Session done. ${sessionTime}s practiced, ${coinsEarned} coins earned.\n`
       )
     );
   }

--- a/src/overlay.ts
+++ b/src/overlay.ts
@@ -3,6 +3,8 @@ import { breathingPatterns } from "./const/patterns";
 import { BreathingPhase } from "./types/BreathingPattern";
 import { emojis, EmojiKey } from "./const/emoji";
 import { loadData, saveData, BreathingData } from "./storage";
+import { Config, getPalette, getDifficultyTier, Palette } from "./config";
+import { visualizers } from "./visualizers";
 
 // ─── State ───────────────────────────────────────────────────────────
 
@@ -18,6 +20,9 @@ let activePhases: BreathingPhase[] = [];
 let phaseIndex = 0;
 let menuOpen = false;
 let menuIndex = 0;
+let config: Config;
+let palette: Palette;
+let tickCounter = 0;
 
 let inputCleanup: (() => void) | null = null;
 
@@ -60,34 +65,37 @@ function render(): void {
   const lines: string[] = [];
 
   lines.push("");
-  lines.push(center(chalk.bold("🌿  calm garden  🌿"), w));
-  lines.push(center(chalk.dim(patternName), w));
+  lines.push(center(palette.primary("🌿  calm garden  🌿"), w));
+  lines.push(center(palette.dim(patternName), w));
   lines.push("");
 
   if (paused) {
-    lines.push(center(chalk.yellow.bold("⏸  PAUSED"), w));
+    lines.push(center(palette.hold("⏸  PAUSED"), w));
   } else {
     const phaseColor =
       currentPhaseName === "Inhale"
-        ? chalk.cyan.bold
+        ? palette.inhale
         : currentPhaseName === "Exhale"
-        ? chalk.green.bold
-        : chalk.yellow.bold;
+        ? palette.exhale
+        : palette.hold;
     lines.push(center(phaseColor(`${currentPhaseName}`), w));
   }
 
   lines.push("");
 
-  const barWidth = Math.min(30, w - 10);
   const progress =
     currentPhaseDuration > 0 ? currentPhaseSecond / currentPhaseDuration : 0;
-  const filled = Math.round(progress * barWidth);
-  const bar =
-    chalk.cyan("█".repeat(filled)) +
-    chalk.dim("░".repeat(barWidth - filled));
-  lines.push(center(bar, w));
+  const vizLines = visualizers[config.visualizer](
+    progress,
+    currentPhaseName,
+    palette,
+    w
+  );
+  for (const line of vizLines) {
+    lines.push(center(line, w));
+  }
   lines.push(
-    center(chalk.dim(`${currentPhaseSecond}/${currentPhaseDuration}s`), w)
+    center(palette.dim(`${currentPhaseSecond}/${currentPhaseDuration}s`), w)
   );
 
   lines.push("");
@@ -112,9 +120,9 @@ function render(): void {
 
   lines.push(
     center(
-      chalk.dim(`☀️ ${data.coins}`) +
-        chalk.dim("  ⏱ ") +
-        chalk.dim(formatTime(sessionTime)),
+      palette.dim(`☀️ ${data.coins}`) +
+        palette.dim("  ⏱ ") +
+        palette.dim(formatTime(sessionTime)),
       w
     )
   );
@@ -123,7 +131,7 @@ function render(): void {
 
   lines.push(
     center(
-      chalk.dim("[space] pause/resume  [m] menu  [q] back"),
+      palette.dim("[space] pause/resume  [m] menu  [q] back"),
       w
     )
   );
@@ -159,23 +167,23 @@ function renderMenu(): void {
 
   const lines: string[] = [];
   lines.push("");
-  lines.push(center(chalk.bold("🌿  select pattern  🌿"), w));
+  lines.push(center(palette.primary("🌿  select pattern  🌿"), w));
   lines.push("");
 
   for (let i = 0; i < breathingPatterns.length; i++) {
     const p = breathingPatterns[i];
     const selected = i === menuIndex;
-    const prefix = selected ? chalk.cyan.bold("▸ ") : "  ";
+    const prefix = selected ? palette.accent("▸ ") : "  ";
     const text = selected
-      ? chalk.cyan.bold(`${p.emoji} ${p.display}`)
-      : chalk.dim(`${p.emoji} ${p.display}`);
+      ? palette.accent(`${p.emoji} ${p.display}`)
+      : palette.dim(`${p.emoji} ${p.display}`);
     lines.push(center(prefix + text, w));
-    lines.push(center(chalk.dim(`  ${p.description}`), w));
+    lines.push(center(palette.dim(`  ${p.description}`), w));
     lines.push("");
   }
 
   lines.push(
-    center(chalk.dim("[↑↓] select  [enter] start  [m] back"), w)
+    center(palette.dim("[↑↓] select  [enter] start  [m] back"), w)
   );
 
   process.stdout.write(lines.join("\n"));
@@ -270,7 +278,12 @@ async function breatheLoop(): Promise<void> {
 
         sessionTime++;
         data.totalSecondsPracticed++;
-        data.coins++;
+        tickCounter++;
+        const tier = getDifficultyTier(config);
+        if (tickCounter >= tier.ticksPerCoin) {
+          data.coins++;
+          tickCounter = 0;
+        }
         await saveData(data);
       }
 
@@ -282,7 +295,8 @@ async function breatheLoop(): Promise<void> {
 // ─── Exported entry point ────────────────────────────────────────────
 
 export async function startBreathingOverlay(
-  patternType: string
+  patternType: string,
+  userConfig: Config
 ): Promise<void> {
   // Reset state for each session
   paused = false;
@@ -290,6 +304,9 @@ export async function startBreathingOverlay(
   sessionTime = 0;
   menuOpen = false;
   menuIndex = 0;
+  tickCounter = 0;
+  config = userConfig;
+  palette = getPalette(config);
 
   data = await loadData();
 

--- a/src/overlay.ts
+++ b/src/overlay.ts
@@ -117,15 +117,28 @@ function render(): void {
   // Garden
   const gardenSize = data.gardenSize;
   const emptyPlot = "🌱";
+  const chalkColors: Record<string, chalk.Chalk> = {
+    red: chalk.red,
+    green: chalk.green,
+    yellow: chalk.yellow,
+    blue: chalk.blue,
+    magenta: chalk.magenta,
+    cyan: chalk.cyan,
+    white: chalk.white,
+  };
   for (let y = 0; y < gardenSize; y++) {
     let row = "";
     for (let x = 0; x < gardenSize; x++) {
       const plant = data.plants.find(
         (p: { x: number; y: number; type: string }) => p.x === x && p.y === y
       );
-      row += plant
-        ? emojis[plant.type as EmojiKey] || emptyPlot
-        : emptyPlot;
+      if (plant) {
+        const glyph = emojis[plant.type as EmojiKey] || emptyPlot;
+        const colorFn = plant.color ? chalkColors[plant.color] : null;
+        row += colorFn ? colorFn(glyph) : glyph;
+      } else {
+        row += emptyPlot;
+      }
     }
     lines.push(center(row, w));
   }

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -1,4 +1,4 @@
-import { exit } from "process";
+import { prompt } from "enquirer";
 import { loadData } from "./storage";
 import { clearConsole } from "./utils";
 
@@ -15,6 +15,13 @@ export async function showProgress(): Promise<void> {
   console.log(`Garden size: ${data.gardenSize}x${data.gardenSize}`);
   console.log(`Number of plants: ${data.plants.length}`);
 
+  console.log("");
+  await prompt<{ action: string }>({
+    type: "select",
+    name: "action",
+    message: "",
+    choices: [{ name: "back", message: "↩ Back" }],
+  });
 }
 function formatTime(seconds: number): string {
   const hours = Math.floor(seconds / 3600);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,146 @@
+import { prompt } from "enquirer";
+import {
+  Config,
+  palettes,
+  PaletteName,
+  difficultyTiers,
+  DifficultyName,
+  priceScaleTiers,
+  PriceScaleName,
+  VisualizerName,
+  saveConfig,
+  getPalette,
+} from "./config";
+import { clearConsole } from "./utils";
+
+export async function showSettings(config: Config): Promise<void> {
+  while (true) {
+    clearConsole();
+    const palette = getPalette(config);
+    console.log(palette.primary("\n⚙️  Settings\n"));
+
+    const response = await prompt<{ setting: string }>({
+      type: "select",
+      name: "setting",
+      message: "Choose a setting to change:",
+      choices: [
+        {
+          name: "palette",
+          message: "🎨 Color Palette",
+          hint: ` (current: ${palettes[config.colorPalette].name})`,
+        },
+        {
+          name: "difficulty",
+          message: "⚡ Difficulty",
+          hint: ` (current: ${config.difficulty})`,
+        },
+        {
+          name: "priceScale",
+          message: "💰 Price Scale",
+          hint: ` (current: ${config.priceScale})`,
+        },
+        {
+          name: "visualizer",
+          message: "🌀 Visualizer",
+          hint: ` (current: ${config.visualizer})`,
+        },
+        { name: "back", message: "↩ Back" },
+      ],
+    });
+
+    if (response.setting === "back") return;
+
+    switch (response.setting) {
+      case "palette":
+        await changePalette(config);
+        break;
+      case "difficulty":
+        await changeDifficulty(config);
+        break;
+      case "priceScale":
+        await changePriceScale(config);
+        break;
+      case "visualizer":
+        await changeVisualizer(config);
+        break;
+    }
+
+    await saveConfig(config);
+  }
+}
+
+async function changePalette(config: Config): Promise<void> {
+  const choices = (Object.keys(palettes) as PaletteName[]).map((key) => ({
+    name: key,
+    message: palettes[key].name,
+    hint: ` — ${palettes[key].description}${key === config.colorPalette ? " (current)" : ""}`,
+  }));
+
+  const response = await prompt<{ choice: PaletteName }>({
+    type: "select",
+    name: "choice",
+    message: "Select color palette:",
+    choices,
+  });
+
+  config.colorPalette = response.choice;
+}
+
+async function changeDifficulty(config: Config): Promise<void> {
+  const choices = difficultyTiers.map((tier) => ({
+    name: tier.name,
+    message: tier.name,
+    hint: ` — ${tier.ticksPerCoin} tick${tier.ticksPerCoin > 1 ? "s" : ""}/coin — ${tier.description}${tier.name === config.difficulty ? " (current)" : ""}`,
+  }));
+
+  const response = await prompt<{ choice: DifficultyName }>({
+    type: "select",
+    name: "choice",
+    message: "Select difficulty:",
+    choices,
+  });
+
+  config.difficulty = response.choice;
+}
+
+async function changePriceScale(config: Config): Promise<void> {
+  const choices = priceScaleTiers.map((tier) => ({
+    name: tier.name,
+    message: tier.name,
+    hint: ` — ${tier.multiplier}x prices — ${tier.description}${tier.name === config.priceScale ? " (current)" : ""}`,
+  }));
+
+  const response = await prompt<{ choice: PriceScaleName }>({
+    type: "select",
+    name: "choice",
+    message: "Select price scale:",
+    choices,
+  });
+
+  config.priceScale = response.choice;
+}
+
+async function changeVisualizer(config: Config): Promise<void> {
+  const visualizerDescriptions: Record<VisualizerName, string> = {
+    "progress-bar": "Classic progress bar",
+    circle: "Expanding/contracting circle",
+    wave: "Flowing sine wave",
+    orb: "Pulsing radial orb",
+    particles: "Floating particles",
+  };
+
+  const choices = (Object.keys(visualizerDescriptions) as VisualizerName[]).map((key) => ({
+    name: key,
+    message: key,
+    hint: ` — ${visualizerDescriptions[key]}${key === config.visualizer ? " (current)" : ""}`,
+  }));
+
+  const response = await prompt<{ choice: VisualizerName }>({
+    type: "select",
+    name: "choice",
+    message: "Select breathing visualizer:",
+    choices,
+  });
+
+  config.visualizer = response.choice;
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -123,8 +123,9 @@ async function changePriceScale(config: Config): Promise<void> {
 async function changeVisualizer(config: Config): Promise<void> {
   const visualizerDescriptions: Record<VisualizerName, string> = {
     "progress-bar": "Classic progress bar",
-    wave: "Flowing sine wave",
+    wave: "Rolling ocean wave",
     orb: "Pulsing radial orb",
+    lotus: "Geometric breathing mandala",
   };
 
   const choices = (Object.keys(visualizerDescriptions) as VisualizerName[]).map((key) => ({

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -123,10 +123,8 @@ async function changePriceScale(config: Config): Promise<void> {
 async function changeVisualizer(config: Config): Promise<void> {
   const visualizerDescriptions: Record<VisualizerName, string> = {
     "progress-bar": "Classic progress bar",
-    circle: "Expanding/contracting circle",
     wave: "Flowing sine wave",
     orb: "Pulsing radial orb",
-    particles: "Floating particles",
   };
 
   const choices = (Object.keys(visualizerDescriptions) as VisualizerName[]).map((key) => ({

--- a/src/shop/actions.ts
+++ b/src/shop/actions.ts
@@ -1,8 +1,20 @@
 import { prompt } from "enquirer";
 import { BreathingData, saveData } from "../storage";
-import { ShopItem, calculateExpansionPrice, getPlantValue, getEffectivePrice } from "./items";
+import {
+  ShopItem,
+  calculateExpansionPrice,
+  getPlantValue,
+  getEffectivePrice,
+  shopItems,
+  rarityOrder,
+  TRADE_COST,
+  getNextTier,
+  isColorable,
+  plantColors,
+  PlantColor,
+} from "./items";
 import { Plant } from "../types/Plant";
-import { emojis } from "../const/emoji";
+import { emojis, EmojiKey } from "../const/emoji";
 import { Config } from "../config";
 
 export async function handleSellPlant(
@@ -97,6 +109,18 @@ export async function handleRegularPurchase(
   const quantity = response.quantity;
   const totalCost = effectivePrice * quantity;
 
+  // Ask for color if this is a colorable plant (exotic glyphs)
+  let chosenColor: PlantColor | undefined;
+  if (isColorable(item)) {
+    const colorResponse = await prompt<{ color: string }>({
+      type: "select",
+      name: "color",
+      message: `Choose a color for your ${item.name}:`,
+      choices: plantColors.map((c) => ({ name: c, message: c })),
+    });
+    chosenColor = colorResponse.color as PlantColor;
+  }
+
   if (data.coins >= totalCost) {
     if (!data.plants) data.plants = [];
     const availableSpaces =
@@ -104,7 +128,7 @@ export async function handleRegularPurchase(
 
     if (availableSpaces >= quantity) {
       for (let i = 0; i < quantity; i++) {
-        const newPlant = placePlantRandomly(data, item);
+        const newPlant = placePlantRandomly(data, item, chosenColor);
         data.plants.push(newPlant);
         console.log(
           `Placed ${item.name} at position (${newPlant.x}, ${newPlant.y})`
@@ -125,14 +149,131 @@ export async function handleRegularPurchase(
 
   saveData(data);
 }
-function placePlantRandomly(data: BreathingData, item: ShopItem): Plant {
+function placePlantRandomly(data: BreathingData, item: ShopItem, color?: PlantColor): Plant {
   let x: number, y: number;
   do {
     x = Math.floor(Math.random() * data.gardenSize);
     y = Math.floor(Math.random() * data.gardenSize);
   } while (data.plants.some((p) => p.x === x && p.y === y));
 
-  return { name: item.name, type: item.type, x, y, growth: 1 };
+  const plant: Plant = { name: item.name, type: item.type, x, y, growth: 1 };
+  if (color) plant.color = color;
+  return plant;
+}
+
+export async function handleTrade(
+  data: BreathingData,
+  config: Config
+): Promise<void> {
+  if (!data.plants || data.plants.length < TRADE_COST) {
+    console.log(`You need at least ${TRADE_COST} plants to trade.`);
+    return;
+  }
+
+  // Find which rarity tiers the player has enough plants to trade
+  const plantsByRarity: Record<string, Plant[]> = {};
+  for (const plant of data.plants) {
+    const item = shopItems.find((i) => i.type === plant.type);
+    if (item?.rarity) {
+      if (!plantsByRarity[item.rarity]) plantsByRarity[item.rarity] = [];
+      plantsByRarity[item.rarity].push(plant);
+    }
+  }
+
+  // Only show tiers with enough plants AND a next tier to upgrade to
+  const tradeable = rarityOrder.filter((tier) => {
+    return (plantsByRarity[tier]?.length ?? 0) >= TRADE_COST && getNextTier(tier);
+  });
+
+  if (tradeable.length === 0) {
+    console.log(`You need ${TRADE_COST} plants of the same rarity tier to trade up.`);
+    console.log("Keep collecting to unlock trades!");
+    return;
+  }
+
+  const tierResponse = await prompt<{ tier: string }>({
+    type: "select",
+    name: "tier",
+    message: `Trade ${TRADE_COST} plants for 1 rarer plant. Pick a tier:`,
+    choices: tradeable.map((tier) => ({
+      name: tier,
+      message: `${tier} (${plantsByRarity[tier].length} owned) → 1 ${getNextTier(tier)}`,
+    })),
+  });
+
+  const tier = tierResponse.tier;
+  const nextTier = getNextTier(tier)!;
+  const candidates = plantsByRarity[tier];
+
+  // Let the user pick which plants to trade
+  const plantChoices = candidates.map((plant, i) => {
+    const emoji = emojis[plant.type as EmojiKey] || "?";
+    return {
+      name: `${emoji} ${plant.name} at (${plant.x}, ${plant.y})`,
+      value: i,
+    };
+  });
+
+  const selected: { plants: string[] } = await prompt({
+    type: "multiselect",
+    name: "plants",
+    message: `Select ${TRADE_COST} ${tier} plants to trade:`,
+    choices: plantChoices,
+    //@ts-expect-error
+    min: TRADE_COST,
+    max: TRADE_COST,
+  });
+
+  if (selected.plants.length !== TRADE_COST) {
+    console.log(`You must select exactly ${TRADE_COST} plants.`);
+    return;
+  }
+
+  // Remove selected plants from garden
+  const plantsToRemove = selected.plants.map((name) => {
+    const idx = plantChoices.findIndex((c) => c.name === name);
+    return candidates[idx];
+  });
+
+  for (const plant of plantsToRemove) {
+    const idx = data.plants.findIndex((p) => p.x === plant.x && p.y === plant.y);
+    if (idx >= 0) data.plants.splice(idx, 1);
+  }
+
+  // Pick a random item from the next tier
+  const nextTierItems = shopItems.filter((i) => i.rarity === nextTier);
+  const reward = nextTierItems[Math.floor(Math.random() * nextTierItems.length)];
+
+  // Check garden space
+  const availableSpaces = data.gardenSize * data.gardenSize - data.plants.length;
+  if (availableSpaces < 1) {
+    console.log("No garden space for the new plant! The trade was cancelled.");
+    return;
+  }
+
+  // Ask for color if the reward is colorable
+  let chosenColor: PlantColor | undefined;
+  if (isColorable(reward)) {
+    const colorResponse = await prompt<{ color: string }>({
+      type: "select",
+      name: "color",
+      message: `Choose a color for your new ${reward.name}:`,
+      choices: plantColors.map((c) => ({ name: c, message: c })),
+    });
+    chosenColor = colorResponse.color as PlantColor;
+  }
+
+  const newPlant = placePlantRandomly(data, reward, chosenColor);
+  data.plants.push(newPlant);
+
+  if (reward.rarity && !data.discovered.includes(reward.type)) {
+    data.discovered.push(reward.type);
+  }
+
+  const emoji = emojis[reward.type as EmojiKey] || "?";
+  console.log(`\n✨ Traded ${TRADE_COST} ${tier} plants for: ${emoji} ${reward.name}!`);
+
+  await saveData(data);
 }
 
 function shuffleGarden(data: BreathingData): void {

--- a/src/shop/actions.ts
+++ b/src/shop/actions.ts
@@ -1,12 +1,14 @@
 import { prompt } from "enquirer";
 import { BreathingData, saveData } from "../storage";
-import { ShopItem, calculateExpansionPrice, getPlantValue } from "./items";
+import { ShopItem, calculateExpansionPrice, getPlantValue, getEffectivePrice } from "./items";
 import { Plant } from "../types/Plant";
 import { emojis } from "../const/emoji";
+import { Config } from "../config";
 
 export async function handleSellPlant(
   data: BreathingData,
-  item: ShopItem
+  item: ShopItem,
+  config: Config
 ): Promise<void> {
   if (!data.plants || data.plants.length === 0) {
     console.log("Your garden is empty. There are no plants to sell.");
@@ -20,7 +22,7 @@ export async function handleSellPlant(
     return {
       name: `${emoji} ${plant.name} at (${plant.x}, ${
         plant.y
-      }) - Value: ${getPlantValue(plant)} coins`,
+      }) - Value: ${getPlantValue(plant, config)} coins`,
       value: index,
     };
   });
@@ -37,7 +39,7 @@ export async function handleSellPlant(
   const plant = data.plants[index];
   data.plants = data.plants.filter((p) => !(p.x == plant.x && p.y == plant.y));
   //console.log("plant", plant);
-  const sellValue = getPlantValue(plant);
+  const sellValue = getPlantValue(plant, config);
   data.coins += sellValue;
   console.log(`You've sold a ${plant.name} for ${sellValue} coins!`);
 
@@ -45,9 +47,10 @@ export async function handleSellPlant(
 }
 
 export async function handleGardenExpansion(
-  data: BreathingData
+  data: BreathingData,
+  config: Config
 ): Promise<void> {
-  const cost = calculateExpansionPrice(data.gardenSize);
+  const cost = calculateExpansionPrice(data.gardenSize, config);
   if (data.coins >= cost) {
     data.coins -= cost;
     data.gardenSize++;
@@ -63,11 +66,13 @@ export async function handleGardenExpansion(
 
 export async function handleShuffleGarden(
   data: BreathingData,
-  item: ShopItem
+  item: ShopItem,
+  config: Config
 ): Promise<void> {
+  const cost = getEffectivePrice(item, config);
   if (data.plants && data.plants.length > 1) {
     shuffleGarden(data);
-    data.coins -= item.cost;
+    data.coins -= cost;
     console.log("Your garden has been shuffled!");
   } else {
     console.log("You need at least two plants to shuffle the garden.");
@@ -76,19 +81,21 @@ export async function handleShuffleGarden(
 
 export async function handleRegularPurchase(
   data: BreathingData,
-  item: ShopItem
+  item: ShopItem,
+  config: Config
 ): Promise<void> {
+  const effectivePrice = getEffectivePrice(item, config);
   const response: { quantity: number } = await prompt({
     type: "numeral",
     name: "quantity",
     message: `How many ${item.name}s do you want to buy?`,
     initial: 1,
     min: 1,
-    max: Math.floor(data.coins / item.cost),
+    max: Math.floor(data.coins / effectivePrice),
   });
 
   const quantity = response.quantity;
-  const totalCost = item.cost * quantity;
+  const totalCost = effectivePrice * quantity;
 
   if (data.coins >= totalCost) {
     if (!data.plants) data.plants = [];

--- a/src/shop/actions.ts
+++ b/src/shop/actions.ts
@@ -16,6 +16,7 @@ import {
 import { Plant } from "../types/Plant";
 import { emojis, EmojiKey } from "../const/emoji";
 import { Config } from "../config";
+import { renderGardenGrid } from "../garden";
 
 export async function handleSellPlant(
   data: BreathingData,
@@ -97,17 +98,13 @@ export async function handleRegularPurchase(
   config: Config
 ): Promise<void> {
   const effectivePrice = getEffectivePrice(item, config);
-  const response: { quantity: number } = await prompt({
-    type: "numeral",
-    name: "quantity",
-    message: `How many ${item.name}s do you want to buy?`,
-    initial: 1,
-    min: 1,
-    max: Math.floor(data.coins / effectivePrice),
-  });
 
-  const quantity = response.quantity;
-  const totalCost = effectivePrice * quantity;
+  if (data.coins < effectivePrice) {
+    console.log("Not enough coins. Keep practicing to earn more!");
+    return;
+  }
+
+  if (!data.plants) data.plants = [];
 
   // Ask for color if this is a colorable plant (exotic glyphs)
   let chosenColor: PlantColor | undefined;
@@ -121,44 +118,71 @@ export async function handleRegularPurchase(
     chosenColor = colorResponse.color as PlantColor;
   }
 
-  if (data.coins >= totalCost) {
-    if (!data.plants) data.plants = [];
-    const availableSpaces =
-      data.gardenSize * data.gardenSize - data.plants.length;
+  // Show garden and let user pick position
+  console.log("\nYour garden:");
+  const lines = renderGardenGrid(data.plants, data.gardenSize, true);
+  for (const line of lines) {
+    console.log(line);
+  }
+  console.log("");
 
-    if (availableSpaces >= quantity) {
-      for (let i = 0; i < quantity; i++) {
-        const newPlant = placePlantRandomly(data, item, chosenColor);
-        data.plants.push(newPlant);
-        console.log(
-          `Placed ${item.name} at position (${newPlant.x}, ${newPlant.y})`
-        );
-      }
-      data.coins -= totalCost;
-      console.log(
-        `You've purchased ${quantity} ${item.name}(s) for your garden for a total of ${totalCost} coins!`
-      );
-    } else {
-      console.log(
-        `Your garden only has space for ${availableSpaces} more plants. Consider expanding your garden.`
-      );
+  const rowChoices = Array.from({ length: data.gardenSize }, (_, i) => ({
+    name: String(i),
+    message: `Row ${i}`,
+  }));
+  const colChoices = Array.from({ length: data.gardenSize }, (_, i) => ({
+    name: String(i),
+    message: `Col ${i}`,
+  }));
+
+  const rowResponse = await prompt<{ row: string }>({
+    type: "select",
+    name: "row",
+    message: "Choose a row:",
+    choices: rowChoices,
+  });
+  const colResponse = await prompt<{ col: string }>({
+    type: "select",
+    name: "col",
+    message: "Choose a column:",
+    choices: colChoices,
+  });
+
+  const y = parseInt(rowResponse.row);
+  const x = parseInt(colResponse.col);
+
+  const existing = data.plants.find((p) => p.x === x && p.y === y);
+  if (existing) {
+    const existingEmoji = emojis[existing.type as EmojiKey] || "?";
+    const replaceResponse = await prompt<{ confirm: string }>({
+      type: "select",
+      name: "confirm",
+      message: `${existingEmoji} ${existing.name} is already at (${x}, ${y}). Replace it?`,
+      choices: [
+        { name: "yes", message: "Yes, replace it" },
+        { name: "no", message: "No, cancel" },
+      ],
+    });
+
+    if (replaceResponse.confirm === "no") {
+      console.log("Purchase cancelled.");
+      return;
     }
-  } else {
-    console.log("Not enough coins. Keep practicing to earn more!");
+
+    // Remove the existing plant
+    data.plants = data.plants.filter((p) => !(p.x === x && p.y === y));
   }
 
-  saveData(data);
-}
-function placePlantRandomly(data: BreathingData, item: ShopItem, color?: PlantColor): Plant {
-  let x: number, y: number;
-  do {
-    x = Math.floor(Math.random() * data.gardenSize);
-    y = Math.floor(Math.random() * data.gardenSize);
-  } while (data.plants.some((p) => p.x === x && p.y === y));
+  const newPlant: Plant = { name: item.name, type: item.type, x, y, growth: 1 };
+  if (chosenColor) newPlant.color = chosenColor;
 
-  const plant: Plant = { name: item.name, type: item.type, x, y, growth: 1 };
-  if (color) plant.color = color;
-  return plant;
+  data.plants.push(newPlant);
+  data.coins -= effectivePrice;
+
+  const emoji = emojis[item.type as EmojiKey] || "?";
+  console.log(`Placed ${emoji} ${item.name} at (${x}, ${y})!`);
+
+  saveData(data);
 }
 
 export async function handleTrade(
@@ -263,7 +287,63 @@ export async function handleTrade(
     chosenColor = colorResponse.color as PlantColor;
   }
 
-  const newPlant = placePlantRandomly(data, reward, chosenColor);
+  // Let user choose where to place the reward
+  console.log("\nChoose where to place your new plant:");
+  const gridLines = renderGardenGrid(data.plants, data.gardenSize, true);
+  for (const line of gridLines) {
+    console.log(line);
+  }
+  console.log("");
+
+  const rowChoices = Array.from({ length: data.gardenSize }, (_, i) => ({
+    name: String(i),
+    message: `Row ${i}`,
+  }));
+  const colChoices = Array.from({ length: data.gardenSize }, (_, i) => ({
+    name: String(i),
+    message: `Col ${i}`,
+  }));
+
+  const rowResp = await prompt<{ row: string }>({
+    type: "select",
+    name: "row",
+    message: "Choose a row:",
+    choices: rowChoices,
+  });
+  const colResp = await prompt<{ col: string }>({
+    type: "select",
+    name: "col",
+    message: "Choose a column:",
+    choices: colChoices,
+  });
+
+  const tradeY = parseInt(rowResp.row);
+  const tradeX = parseInt(colResp.col);
+
+  // Replace any existing plant at the chosen position
+  const existingAtSpot = data.plants.find((p) => p.x === tradeX && p.y === tradeY);
+  if (existingAtSpot) {
+    const existingEmoji = emojis[existingAtSpot.type as EmojiKey] || "?";
+    const replaceResp = await prompt<{ confirm: string }>({
+      type: "select",
+      name: "confirm",
+      message: `${existingEmoji} ${existingAtSpot.name} is at (${tradeX}, ${tradeY}). Replace it?`,
+      choices: [
+        { name: "yes", message: "Yes, replace it" },
+        { name: "no", message: "No, cancel" },
+      ],
+    });
+    if (replaceResp.confirm === "no") {
+      console.log("Trade cancelled. Your plants have been returned.");
+      // Re-add the removed plants
+      data.plants.push(...plantsToRemove);
+      return;
+    }
+    data.plants = data.plants.filter((p) => !(p.x === tradeX && p.y === tradeY));
+  }
+
+  const newPlant: Plant = { name: reward.name, type: reward.type, x: tradeX, y: tradeY, growth: 1 };
+  if (chosenColor) newPlant.color = chosenColor;
   data.plants.push(newPlant);
 
   if (reward.rarity && !data.discovered.includes(reward.type)) {

--- a/src/shop/items.ts
+++ b/src/shop/items.ts
@@ -65,6 +65,7 @@ export const shopItems: ShopItem[] = [
   { name: "Garden Expansion", type: "expansion", cost: 0 },
   { name: "Shuffle Garden", type: "shuffle", cost: 50 },
   { name: "Sell Plant", type: "sell", cost: -20 },
+  { name: "Trade Plants", type: "trade", cost: 0 },
 ];
 
 export function initializeShopItems(): void {
@@ -79,6 +80,54 @@ export function getEffectivePrice(item: ShopItem, config: Config): number {
 
 export function calculateExpansionPrice(currentSize: number, config: Config): number {
   return Math.floor(100 * Math.pow(1.5, currentSize - 3) * getPriceMultiplier(config));
+}
+
+// ─── Rarity progression ─────────────────────────────────────────────
+
+export const rarityOrder = ["common", "uncommon", "rare", "exotic", "epic", "legendary"] as const;
+
+const unlockRequirements: Record<string, { prevTier: string; count: number }> = {
+  uncommon: { prevTier: "common", count: 2 },
+  rare: { prevTier: "uncommon", count: 2 },
+  exotic: { prevTier: "rare", count: 2 },
+  epic: { prevTier: "exotic", count: 2 },
+  legendary: { prevTier: "epic", count: 2 },
+};
+
+export function isTierUnlocked(tier: string, discovered: string[]): boolean {
+  const req = unlockRequirements[tier];
+  if (!req) return true; // common is always unlocked
+  const prevTierItems = shopItems.filter((i) => i.rarity === req.prevTier);
+  const discoveredCount = prevTierItems.filter((i) => discovered.includes(i.type)).length;
+  return discoveredCount >= req.count;
+}
+
+export function getUnlockHint(tier: string, discovered: string[]): string {
+  const req = unlockRequirements[tier];
+  if (!req) return "";
+  const prevTierItems = shopItems.filter((i) => i.rarity === req.prevTier);
+  const discoveredCount = prevTierItems.filter((i) => discovered.includes(i.type)).length;
+  return `Discover ${req.count - discoveredCount} more ${req.prevTier} items to unlock`;
+}
+
+// Plants that use text glyphs (not emoji) can be colored
+const colorableTiers = new Set(["exotic"]);
+
+export function isColorable(item: ShopItem): boolean {
+  return !!item.rarity && colorableTiers.has(item.rarity);
+}
+
+export const plantColors = ["red", "green", "yellow", "blue", "magenta", "cyan", "white"] as const;
+export type PlantColor = typeof plantColors[number];
+
+// ─── Trade recipes ──────────────────────────────────────────────────
+
+export const TRADE_COST = 3; // 3 plants of tier N → 1 random plant of tier N+1
+
+export function getNextTier(tier: string): string | null {
+  const idx = rarityOrder.indexOf(tier as any);
+  if (idx < 0 || idx >= rarityOrder.length - 1) return null;
+  return rarityOrder[idx + 1];
 }
 
 export function getPlantValue(plant: Plant, config: Config): number {

--- a/src/shop/items.ts
+++ b/src/shop/items.ts
@@ -38,10 +38,21 @@ export const shopItems: ShopItem[] = [
   { name: "Tree", type: "tree", cost: 200, rarity: "rare" },
   { name: "Palm", type: "palm", cost: 175, rarity: "rare" },
 
+  // Exotic — 220-380 coins (ASCII/Unicode glyphs)
+  { name: "Fern Glyph", type: "fern-glyph", cost: 220, rarity: "exotic" },
+  { name: "Star Moss", type: "star-moss", cost: 240, rarity: "exotic" },
+  { name: "Hex Bloom", type: "hex-bloom", cost: 230, rarity: "exotic" },
+  { name: "Spiral Fern", type: "spiral-fern", cost: 260, rarity: "exotic" },
+  { name: "Rune Sprout", type: "rune-sprout", cost: 280, rarity: "exotic" },
+  { name: "Sigil Vine", type: "sigil-vine", cost: 300, rarity: "exotic" },
+  { name: "Thorn Script", type: "thorn-script", cost: 320, rarity: "exotic" },
+  { name: "Eye Cluster", type: "eye-cluster", cost: 380, rarity: "exotic" },
+
   // Epic — 400-600 coins (5-10 minutes)
   { name: "Lotus", type: "lotus", cost: 400, rarity: "epic" },
   { name: "Cherry Blossom", type: "cherry-blossom", cost: 500, rarity: "epic" },
   { name: "Bonsai", type: "bonsai", cost: 600, rarity: "epic" },
+  { name: "Orchid", type: "orchid", cost: 450, rarity: "epic" },
 
   // Legendary — 1000+ coins (15+ minutes)
   { name: "Dragon Fruit", type: "dragon-fruit", cost: 1000, rarity: "legendary" },

--- a/src/shop/items.ts
+++ b/src/shop/items.ts
@@ -6,84 +6,51 @@ export interface ShopItem {
   type: string;
   cost: number;
   emoji?: string;
+  rarity?: string;
 }
 
-const price1 = 50;
 export const shopItems: ShopItem[] = [
-  {
-    name: "Arugula",
-    type: "arugula",
-    cost: price1,
-  },
-  { name: "Daisy", type: "daisy", cost: price1 },
-  { name: "Iris", type: "iris", cost: price1 },
-  { name: "Lotus", type: "lotus", cost: price1 },
-  {
-    name: "Marigold",
-    type: "marigold",
-    cost: price1,
-  },
-  {
-    name: "Pink Rose",
-    type: "pink-rose",
-    cost: price1,
-  },
-  { name: "Poppy", type: "poppy", cost: price1 },
-  {
-    name: "Sunflower",
-    type: "sunflower",
-    cost: price1,
-  },
-  { name: "Tomato", type: "tomato", cost: price1 },
-  { name: "Tree", type: "tree", cost: price1 },
-  { name: "Cactus", type: "cactus", cost: price1 },
-  { name: "Palm", type: "palm", cost: price1 },
-  { name: "Bonsai", type: "bonsai", cost: price1 },
-  { name: "Bamboo", type: "bamboo", cost: price1 },
-  {
-    name: "Hibiscus",
-    type: "hibiscus",
-    cost: price1,
-  },
-  { name: "Orchid", type: "orchid", cost: price1 },
-  {
-    name: "Cherry Blossom",
-    type: "cherry-blossom",
-    cost: price1,
-  },
-  {
-    name: "Mushroom",
-    type: "mushroom",
-    cost: price1,
-  },
-  { name: "Herb", type: "herb", cost: price1 },
-  {
-    name: "Seedling",
-    type: "seedling",
-    cost: price1,
-  },
-  { name: "Leaves", type: "leaves", cost: price1 },
-  {
-    name: "Four Leaf Clover",
-    type: "four-leaf-clover",
-    cost: price1,
-  },
-  {
-    name: "Maple Leaf",
-    type: "maple-leaf",
-    cost: price1,
-  },
-  {
-    name: "Evergreen",
-    type: "evergreen",
-    cost: price1,
-  },
-  { name: "Rock", type: "rock", cost: price1 },
-  {
-    name: "Garden Expansion",
-    type: "expansion",
-    cost: 0,
-  },
+  // Common — 20-30 coins (a few seconds of practice)
+  { name: "Seedling", type: "seedling", cost: 10, rarity: "common" },
+  { name: "Herb", type: "herb", cost: 20, rarity: "common" },
+  { name: "Leaves", type: "leaves", cost: 20, rarity: "common" },
+  { name: "Arugula", type: "arugula", cost: 25, rarity: "common" },
+  { name: "Mushroom", type: "mushroom", cost: 25, rarity: "common" },
+  { name: "Rock", type: "rock", cost: 15, rarity: "common" },
+
+  // Uncommon — 50-80 coins (about a minute)
+  { name: "Daisy", type: "daisy", cost: 50, rarity: "uncommon" },
+  { name: "Poppy", type: "poppy", cost: 50, rarity: "uncommon" },
+  { name: "Cactus", type: "cactus", cost: 60, rarity: "uncommon" },
+  { name: "Bamboo", type: "bamboo", cost: 60, rarity: "uncommon" },
+  { name: "Four Leaf Clover", type: "four-leaf-clover", cost: 70, rarity: "uncommon" },
+  { name: "Maple Leaf", type: "maple-leaf", cost: 55, rarity: "uncommon" },
+  { name: "Tomato", type: "tomato", cost: 65, rarity: "uncommon" },
+  { name: "Tulip", type: "tulip", cost: 75, rarity: "uncommon" },
+
+  // Rare — 120-200 coins (a few minutes)
+  { name: "Sunflower", type: "sunflower", cost: 120, rarity: "rare" },
+  { name: "Pink Rose", type: "pink-rose", cost: 150, rarity: "rare" },
+  { name: "Hibiscus", type: "hibiscus", cost: 140, rarity: "rare" },
+  { name: "Iris", type: "iris", cost: 130, rarity: "rare" },
+  { name: "Marigold", type: "marigold", cost: 160, rarity: "rare" },
+  { name: "Evergreen", type: "evergreen", cost: 180, rarity: "rare" },
+  { name: "Tree", type: "tree", cost: 200, rarity: "rare" },
+  { name: "Palm", type: "palm", cost: 175, rarity: "rare" },
+
+  // Epic — 400-600 coins (5-10 minutes)
+  { name: "Lotus", type: "lotus", cost: 400, rarity: "epic" },
+  { name: "Cherry Blossom", type: "cherry-blossom", cost: 500, rarity: "epic" },
+  { name: "Bonsai", type: "bonsai", cost: 600, rarity: "epic" },
+
+  // Legendary — 1000+ coins (15+ minutes)
+  { name: "Dragon Fruit", type: "dragon-fruit", cost: 1000, rarity: "legendary" },
+  { name: "Crystal Flower", type: "crystal-flower", cost: 1500, rarity: "legendary" },
+  { name: "Golden Bloom", type: "golden-bloom", cost: 2000, rarity: "legendary" },
+  { name: "Ancient Tree", type: "ancient-tree", cost: 3000, rarity: "legendary" },
+
+  // Utility
+  { name: "Garden Expansion", type: "expansion", cost: 0 },
   { name: "Shuffle Garden", type: "shuffle", cost: 50 },
   { name: "Sell Plant", type: "sell", cost: -20 },
 ];
@@ -97,13 +64,10 @@ export function initializeShopItems(): void {
 export function calculateExpansionPrice(currentSize: number): number {
   return Math.floor(100 * Math.pow(1.5, currentSize - 3));
 }
+
 export function getPlantValue(plant: Plant): number {
-  // Base value for the plant type
   const baseValue =
     shopItems.find((item) => item.name === plant.name)?.cost || 10;
-
-  // Increase value based on growth
-  const growthMultiplier = 1 + (plant.growth - 1) * 0.1; // 10% increase per growth level
-
+  const growthMultiplier = 1 + (plant.growth - 1) * 0.1;
   return Math.round(baseValue * growthMultiplier);
 }

--- a/src/shop/items.ts
+++ b/src/shop/items.ts
@@ -1,5 +1,6 @@
 import { emojis, EmojiKey } from "../const/emoji";
 import { Plant } from "../types/Plant";
+import { Config, getPriceMultiplier } from "../config";
 
 export interface ShopItem {
   name: string;
@@ -72,13 +73,17 @@ export function initializeShopItems(): void {
   }
 }
 
-export function calculateExpansionPrice(currentSize: number): number {
-  return Math.floor(100 * Math.pow(1.5, currentSize - 3));
+export function getEffectivePrice(item: ShopItem, config: Config): number {
+  return Math.floor(item.cost * getPriceMultiplier(config));
 }
 
-export function getPlantValue(plant: Plant): number {
+export function calculateExpansionPrice(currentSize: number, config: Config): number {
+  return Math.floor(100 * Math.pow(1.5, currentSize - 3) * getPriceMultiplier(config));
+}
+
+export function getPlantValue(plant: Plant, config: Config): number {
   const baseValue =
     shopItems.find((item) => item.name === plant.name)?.cost || 10;
   const growthMultiplier = 1 + (plant.growth - 1) * 0.1;
-  return Math.round(baseValue * growthMultiplier);
+  return Math.round(baseValue * growthMultiplier * getPriceMultiplier(config));
 }

--- a/src/shop/service.ts
+++ b/src/shop/service.ts
@@ -1,6 +1,6 @@
 import { prompt } from "enquirer";
 import { BreathingData, saveData, loadData } from "../storage";
-import { clearConsole } from "../utils";
+import { clearConsole, sleep } from "../utils";
 import {
   ShopItem,
   initializeShopItems,
@@ -14,9 +14,9 @@ import {
   handleShuffleGarden,
   handleRegularPurchase,
 } from "./actions";
-import { sleep } from "../utils";
 import { Config, getPalette } from "../config";
 import { plantLore } from "../const/lore";
+import { emojis, EmojiKey } from "../const/emoji";
 
 export async function showShop(config: Config): Promise<void> {
   let data = await loadData();
@@ -42,7 +42,10 @@ export async function showShop(config: Config): Promise<void> {
     const item = shopItems.find((x) => response.choice.includes(x.name));
 
     if (item) {
-      await purchaseItem(data, item, config);
+      const shouldBuy = await showItemDetail(item, data, config);
+      if (shouldBuy) {
+        await purchaseItem(data, item, config);
+      }
     } else {
       console.log("Invalid selection. Please try again.");
       await sleep(2000);
@@ -72,6 +75,49 @@ async function purchaseItem(
   await handler();
   await saveData(data);
   await sleep(2000);
+}
+
+async function showItemDetail(
+  item: ShopItem,
+  data: BreathingData,
+  config: Config
+): Promise<boolean> {
+  const palette = getPalette(config);
+  const lore = plantLore[item.type];
+  const emoji = emojis[item.type as EmojiKey] || item.emoji || "?";
+  const price = item.name === "Garden Expansion"
+    ? calculateExpansionPrice(data.gardenSize, config)
+    : getEffectivePrice(item, config);
+
+  clearConsole();
+  console.log("");
+  console.log(palette.primary(`  ${emoji}  ${item.name}`));
+  if (lore) {
+    console.log(palette.accent(`  ${lore.latin}`));
+  }
+  console.log("");
+  if (item.rarity) {
+    console.log(palette.dim(`  Rarity: ${item.rarity}`));
+  }
+  console.log(palette.dim(`  Cost: ${price} coins`));
+  console.log(palette.dim(`  You have: ${data.coins} coins`));
+  console.log("");
+  if (lore) {
+    console.log(`  "${lore.lore}"`);
+    console.log("");
+  }
+
+  const response = await prompt<{ action: string }>({
+    type: "select",
+    name: "action",
+    message: "",
+    choices: [
+      { name: "buy", message: "💰 Buy" },
+      { name: "back", message: "↩ Back" },
+    ],
+  });
+
+  return response.action === "buy";
 }
 
 function createShopMenu(

--- a/src/shop/service.ts
+++ b/src/shop/service.ts
@@ -6,6 +6,7 @@ import {
   initializeShopItems,
   shopItems,
   calculateExpansionPrice,
+  getEffectivePrice,
 } from "./items";
 import {
   handleSellPlant,
@@ -14,8 +15,10 @@ import {
   handleRegularPurchase,
 } from "./actions";
 import { sleep } from "../utils";
+import { Config, getPalette } from "../config";
+import { plantLore } from "../const/lore";
 
-export async function showShop(): Promise<void> {
+export async function showShop(config: Config): Promise<void> {
   let data = await loadData();
   initializeShopItems();
 
@@ -25,7 +28,7 @@ export async function showShop(): Promise<void> {
     console.log(`💰 You have ${data.coins} coins.`);
     console.log(`🌳 Your garden size: ${data.gardenSize}x${data.gardenSize}\n`);
 
-    const choices = createShopMenu(data);
+    const choices = createShopMenu(data, config);
 
     const response = await prompt<{ choice: string }>({
       type: "select",
@@ -39,7 +42,7 @@ export async function showShop(): Promise<void> {
     const item = shopItems.find((x) => response.choice.includes(x.name));
 
     if (item) {
-      await purchaseItem(data, item);
+      await purchaseItem(data, item, config);
     } else {
       console.log("Invalid selection. Please try again.");
       await sleep(2000);
@@ -49,16 +52,22 @@ export async function showShop(): Promise<void> {
 
 async function purchaseItem(
   data: BreathingData,
-  item: ShopItem
+  item: ShopItem,
+  config: Config
 ): Promise<void> {
   const handlers: Record<string, () => Promise<void>> = {
-    "Sell Plant": async () => await handleSellPlant(data, item),
-    "Garden Expansion": async () => await handleGardenExpansion(data),
-    "Shuffle Garden": async () => await handleShuffleGarden(data, item),
+    "Sell Plant": async () => await handleSellPlant(data, item, config),
+    "Garden Expansion": async () => await handleGardenExpansion(data, config),
+    "Shuffle Garden": async () => await handleShuffleGarden(data, item, config),
   };
 
   const handler =
-    handlers[item.name] || (() => handleRegularPurchase(data, item));
+    handlers[item.name] || (async () => {
+      await handleRegularPurchase(data, item, config);
+      if (item.rarity && !data.discovered.includes(item.type)) {
+        data.discovered.push(item.type);
+      }
+    });
 
   await handler();
   await saveData(data);
@@ -66,22 +75,30 @@ async function purchaseItem(
 }
 
 function createShopMenu(
-  data: BreathingData
+  data: BreathingData,
+  config: Config
 ): Array<{ name: string; value: number; hint: string }> {
-  const expansionPrice = calculateExpansionPrice(data.gardenSize);
-  const choices = shopItems.map((item, index) => ({
-    name:
-      item.name === "Garden Expansion"
-        ? `${item.emoji} ${item.name} (${data.gardenSize + 1}x${
-            data.gardenSize + 1
-          })`
-        : `${item.emoji} ${item.name}`,
-    value: index,
-    hint:
-      item.name === "Garden Expansion"
-        ? ` (Cost: ${expansionPrice} coins)`
-        : ` (Cost: ${item.cost} coins)`,
-  }));
+  const choices = shopItems.map((item, index) => {
+    const price = item.name === "Garden Expansion"
+      ? calculateExpansionPrice(data.gardenSize, config)
+      : item.name === "Sell Plant"
+      ? 0
+      : getEffectivePrice(item, config);
+    const lore = plantLore[item.type];
+    const loreHint = lore ? ` — ${lore.latin}` : "";
+
+    return {
+      name:
+        item.name === "Garden Expansion"
+          ? `${item.emoji} ${item.name} (${data.gardenSize + 1}x${data.gardenSize + 1})`
+          : `${item.emoji} ${item.name}${loreHint}`,
+      value: index,
+      hint:
+        item.name === "Sell Plant"
+          ? " (sell a plant)"
+          : ` (${price} coins)`,
+    };
+  });
   choices.push({ name: "🚪 Exit Shop", value: -1, hint: "Leave the shop" });
   return choices;
 }

--- a/src/shop/service.ts
+++ b/src/shop/service.ts
@@ -7,12 +7,15 @@ import {
   shopItems,
   calculateExpansionPrice,
   getEffectivePrice,
+  isTierUnlocked,
+  getUnlockHint,
 } from "./items";
 import {
   handleSellPlant,
   handleGardenExpansion,
   handleShuffleGarden,
   handleRegularPurchase,
+  handleTrade,
 } from "./actions";
 import { Config, getPalette } from "../config";
 import { plantLore } from "../const/lore";
@@ -58,10 +61,18 @@ async function purchaseItem(
   item: ShopItem,
   config: Config
 ): Promise<void> {
+  // Enforce unlock gates for rarity-gated items
+  if (item.rarity && !isTierUnlocked(item.rarity, data.discovered)) {
+    console.log(`🔒 ${getUnlockHint(item.rarity, data.discovered)}`);
+    await sleep(2000);
+    return;
+  }
+
   const handlers: Record<string, () => Promise<void>> = {
     "Sell Plant": async () => await handleSellPlant(data, item, config),
     "Garden Expansion": async () => await handleGardenExpansion(data, config),
     "Shuffle Garden": async () => await handleShuffleGarden(data, item, config),
+    "Trade Plants": async () => await handleTrade(data, config),
   };
 
   const handler =
@@ -123,28 +134,49 @@ async function showItemDetail(
 function createShopMenu(
   data: BreathingData,
   config: Config
-): Array<{ name: string; value: number; hint: string }> {
-  const choices = shopItems.map((item, index) => {
+): Array<{ name: string; value: number; hint: string; disabled?: string }> {
+  const choices: Array<{ name: string; value: number; hint: string; disabled?: string }> = [];
+
+  for (let i = 0; i < shopItems.length; i++) {
+    const item = shopItems[i];
     const price = item.name === "Garden Expansion"
       ? calculateExpansionPrice(data.gardenSize, config)
       : item.name === "Sell Plant"
+      ? 0
+      : item.name === "Trade Plants"
       ? 0
       : getEffectivePrice(item, config);
     const lore = plantLore[item.type];
     const loreHint = lore ? ` — ${lore.latin}` : "";
 
-    return {
-      name:
-        item.name === "Garden Expansion"
-          ? `${item.emoji} ${item.name} (${data.gardenSize + 1}x${data.gardenSize + 1})`
-          : `${item.emoji} ${item.name}${loreHint}`,
-      value: index,
-      hint:
-        item.name === "Sell Plant"
-          ? " (sell a plant)"
-          : ` (${price} coins)`,
-    };
-  });
+    // Check if this rarity tier is locked
+    const locked = item.rarity && !isTierUnlocked(item.rarity, data.discovered);
+
+    if (locked) {
+      choices.push({
+        name: `🔒 ${item.name}`,
+        value: i,
+        hint: ` (${getUnlockHint(item.rarity!, data.discovered)})`,
+      });
+    } else {
+      choices.push({
+        name:
+          item.name === "Garden Expansion"
+            ? `${item.emoji} ${item.name} (${data.gardenSize + 1}x${data.gardenSize + 1})`
+            : item.name === "Trade Plants"
+            ? `${item.emoji} ${item.name}`
+            : `${item.emoji} ${item.name}${loreHint}`,
+        value: i,
+        hint:
+          item.name === "Sell Plant"
+            ? " (sell a plant)"
+            : item.name === "Trade Plants"
+            ? " (trade 3 plants → 1 rarer plant)"
+            : ` (${price} coins)`,
+      });
+    }
+  }
+
   choices.push({ name: "🚪 Exit Shop", value: -1, hint: "Leave the shop" });
   return choices;
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -8,6 +8,7 @@ export interface BreathingData {
   coins: number; // number representing the user's current coins. can be used to expand garden, plant new plants, etc.
   gardenSize: number; // number representing the user's current garden size
   plants: Plant[]; // 2d grid representing the user's garden. this will be used to visualize the user's progress
+  discovered: string[]; // plant types the user has unlocked/discovered
 }
 
 function getStoragePath() {
@@ -29,11 +30,18 @@ export const defaultData: BreathingData = {
   gardenSize: 3,
   plants: [],
   coins: 0,
+  discovered: [],
 };
 
 export async function loadData(): Promise<BreathingData> {
   const storedData = (await storage.getItem("breathingData")) || {};
-  return { ...defaultData, ...storedData };
+  const data = { ...defaultData, ...storedData };
+  // Backfill discovered from existing plants if missing
+  if (!storedData.discovered && data.plants.length > 0) {
+    data.discovered = [...new Set(data.plants.map((p: Plant) => p.type))];
+    await saveData(data);
+  }
+  return data;
 }
 
 export async function saveData(data: BreathingData): Promise<void> {

--- a/src/types/Plant.ts
+++ b/src/types/Plant.ts
@@ -7,4 +7,6 @@ export interface Plant {
   growth: number;
   x: number;
   y: number;
+  /** optional color override for text-based plants (exotic+) */
+  color?: string;
 }

--- a/src/visualizers.ts
+++ b/src/visualizers.ts
@@ -1,0 +1,183 @@
+import { Palette } from "./config";
+
+export type VisualizerFn = (
+  progress: number,
+  phase: string,
+  palette: Palette,
+  width: number
+) => string[];
+
+// ─── Progress Bar ───────────────────────────────────────────────────
+
+function progressBar(
+  progress: number,
+  _phase: string,
+  palette: Palette,
+  width: number
+): string[] {
+  const barWidth = Math.min(30, width - 10);
+  const filled = Math.round(progress * barWidth);
+  const bar =
+    palette.bar("█".repeat(filled)) +
+    palette.dim("░".repeat(barWidth - filled));
+  return [bar];
+}
+
+// ─── Circle ─────────────────────────────────────────────────────────
+
+function circle(
+  progress: number,
+  _phase: string,
+  palette: Palette,
+  _width: number
+): string[] {
+  const maxRadius = 4;
+  const radius = Math.max(1, Math.round(progress * maxRadius));
+  const size = radius * 2 + 1;
+  const lines: string[] = [];
+
+  for (let y = 0; y < size; y++) {
+    let row = "";
+    for (let x = 0; x < size * 2; x++) {
+      const dx = (x / 2) - radius;
+      const dy = y - radius;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+
+      if (Math.abs(dist - radius) < 0.6) {
+        row += palette.accent("·");
+      } else if (dist < 0.8) {
+        row += palette.bar("●");
+      } else if (dist < radius * 0.5 && radius > 2) {
+        row += palette.dim("◦");
+      } else {
+        row += " ";
+      }
+    }
+    lines.push(row);
+  }
+  return lines;
+}
+
+// ─── Wave ───────────────────────────────────────────────────────────
+
+function wave(
+  progress: number,
+  _phase: string,
+  palette: Palette,
+  width: number
+): string[] {
+  const waveWidth = Math.min(40, width - 10);
+  const rows = 7;
+  const amplitude = Math.max(0.5, progress * 3);
+  const midRow = Math.floor(rows / 2);
+  const chars = ["∿", "≈", "∼", "~"];
+  const grid: string[][] = [];
+
+  for (let r = 0; r < rows; r++) {
+    grid.push(new Array(waveWidth).fill(" "));
+  }
+
+  for (let x = 0; x < waveWidth; x++) {
+    const t = (x / waveWidth) * Math.PI * 2;
+    const y = Math.sin(t + progress * Math.PI) * amplitude;
+    const row = Math.round(midRow - y);
+    if (row >= 0 && row < rows) {
+      const charIdx = Math.floor(Math.abs(y) / amplitude * (chars.length - 1));
+      const ch = chars[Math.min(charIdx, chars.length - 1)];
+      grid[row][x] = palette.accent(ch);
+    }
+  }
+
+  return grid.map((row) => row.join(""));
+}
+
+// ─── Orb ────────────────────────────────────────────────────────────
+
+function orb(
+  progress: number,
+  _phase: string,
+  palette: Palette,
+  _width: number
+): string[] {
+  const maxRadius = 4;
+  const radius = Math.max(1, Math.round(progress * maxRadius));
+  const size = maxRadius * 2 + 1;
+  const center = maxRadius;
+  const ringChars = ["✦", "*", "•", "°", "·"];
+  const lines: string[] = [];
+
+  for (let y = 0; y < size; y++) {
+    let row = "";
+    for (let x = 0; x < size * 2; x++) {
+      const dx = (x / 2) - center;
+      const dy = y - center;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+
+      if (dist < 0.8) {
+        row += palette.bar("✦");
+      } else if (dist <= radius) {
+        const ringIndex = Math.min(
+          Math.floor((dist / radius) * (ringChars.length - 1)),
+          ringChars.length - 1
+        );
+        const ch = ringChars[ringIndex];
+        if (dist <= radius * 0.4) {
+          row += palette.bar(ch);
+        } else if (dist <= radius * 0.7) {
+          row += palette.accent(ch);
+        } else {
+          row += palette.dim(ch);
+        }
+      } else {
+        row += " ";
+      }
+    }
+    lines.push(row);
+  }
+  return lines;
+}
+
+// ─── Particles ──────────────────────────────────────────────────────
+
+function particles(
+  progress: number,
+  _phase: string,
+  palette: Palette,
+  width: number
+): string[] {
+  const particleWidth = Math.min(30, width - 10);
+  const rows = 7;
+  const chars = ["·", "°", "•", "✧", "✦"];
+  const grid: string[][] = [];
+
+  for (let r = 0; r < rows; r++) {
+    grid.push(new Array(particleWidth).fill(" "));
+  }
+
+  const seeds = [3, 7, 11, 15, 19, 23, 27, 5, 13, 21, 9, 17, 25, 1, 29];
+  for (let i = 0; i < seeds.length; i++) {
+    const x = seeds[i] % particleWidth;
+    const baseRow = rows - 1 - (i % rows);
+    const offset = Math.round(progress * (rows - 1));
+    const row = baseRow - offset + Math.floor(i / rows);
+    const wrappedRow = ((row % rows) + rows) % rows;
+
+    if (wrappedRow >= 0 && wrappedRow < rows && x < particleWidth) {
+      const ch = chars[i % chars.length];
+      const colorFn = i % 3 === 0 ? palette.bar : i % 3 === 1 ? palette.accent : palette.dim;
+      grid[wrappedRow][x] = colorFn(ch);
+    }
+  }
+
+  return grid.map((row) => row.join(""));
+}
+
+// ─── Registry ───────────────────────────────────────────────────────
+
+export const visualizers: Record<string, VisualizerFn> = {
+  "progress-bar": progressBar,
+  circle,
+  wave,
+  orb,
+  particles,
+};

--- a/src/visualizers.ts
+++ b/src/visualizers.ts
@@ -31,25 +31,42 @@ function wave(
   palette: Palette,
   width: number
 ): string[] {
-  const waveWidth = Math.min(40, width - 10);
+  const waveWidth = Math.min(44, width - 10);
   const rows = 7;
-  const amplitude = Math.max(0.5, progress * 3);
+  const amplitude = Math.max(0.8, progress * 3);
   const midRow = Math.floor(rows / 2);
-  const chars = ["∿", "≈", "∼", "~"];
+  const chars = ["█", "▓", "▒", "░"];
   const grid: string[][] = [];
+
+  // Continuous time offset creates the rightward-originating rolling effect
+  const time = Date.now() / 600;
 
   for (let r = 0; r < rows; r++) {
     grid.push(new Array(waveWidth).fill(" "));
   }
 
-  for (let x = 0; x < waveWidth; x++) {
-    const t = (x / waveWidth) * Math.PI * 2;
-    const y = Math.sin(t + progress * Math.PI) * amplitude;
-    const row = Math.round(midRow - y);
-    if (row >= 0 && row < rows) {
-      const charIdx = Math.floor(Math.abs(y) / amplitude * (chars.length - 1));
-      const ch = chars[Math.min(charIdx, chars.length - 1)];
-      grid[row][x] = palette.accent(ch);
+  // Two layered waves for depth
+  for (let layer = 0; layer < 2; layer++) {
+    const freq = layer === 0 ? 1.5 : 2.2;
+    const layerAmp = layer === 0 ? amplitude : amplitude * 0.5;
+    const layerChars = layer === 0 ? chars : chars.slice(2);
+    const colorFn = layer === 0 ? palette.accent : palette.dim;
+
+    for (let x = 0; x < waveWidth; x++) {
+      // Wave travels left: positive time offset + x produces rightward origin
+      const t = ((x / waveWidth) * Math.PI * 2 * freq) - time + (layer * 0.8);
+      const y = Math.sin(t) * layerAmp;
+      const row = Math.round(midRow - y);
+      if (row >= 0 && row < rows) {
+        const charIdx = Math.floor(
+          (Math.abs(y) / Math.max(0.01, layerAmp)) * (layerChars.length - 1)
+        );
+        const ch = layerChars[Math.min(charIdx, layerChars.length - 1)];
+        // Front layer overwrites back layer
+        if (layer === 0 || grid[row][x] === " ") {
+          grid[row][x] = colorFn(ch);
+        }
+      }
     }
   }
 
@@ -102,10 +119,82 @@ function orb(
   return lines;
 }
 
+// ─── Lotus ──────────────────────────────────────────────────────────
+
+function lotus(
+  progress: number,
+  _phase: string,
+  palette: Palette,
+  _width: number
+): string[] {
+  const time = Date.now() / 1000;
+  const size = 9;
+  const center = Math.floor(size / 2);
+  const breathScale = 0.5 + progress * 0.5; // 0.5 → 1.0
+  const petals = 8;
+  const grid: string[][] = [];
+
+  for (let r = 0; r < size; r++) {
+    grid.push(new Array(size * 2).fill(" "));
+  }
+
+  // Draw petals radiating from center
+  for (let p = 0; p < petals; p++) {
+    const baseAngle = (p / petals) * Math.PI * 2;
+    // Slow rotation
+    const angle = baseAngle + time * 0.4;
+    // Petals breathe in and out
+    const petalLength = 1.5 + breathScale * 2.5;
+
+    for (let d = 0.3; d <= petalLength; d += 0.3) {
+      const px = center + Math.cos(angle) * d * 2; // *2 for aspect ratio
+      const py = center + Math.sin(angle) * d;
+      const col = Math.round(px);
+      const row = Math.round(py);
+
+      if (row >= 0 && row < size && col >= 0 && col < size * 2) {
+        const t = d / petalLength;
+        if (t < 0.33) {
+          grid[row][col] = palette.bar("◆");
+        } else if (t < 0.66) {
+          grid[row][col] = palette.accent("◇");
+        } else {
+          grid[row][col] = palette.dim("·");
+        }
+      }
+    }
+  }
+
+  // Center jewel
+  grid[center][center * 2] = palette.bar("✦");
+  if (center * 2 + 1 < size * 2) {
+    grid[center][center * 2 + 1] = palette.bar("✦");
+  }
+
+  // Outer ring that pulses with breath
+  const ringRadius = 1 + breathScale * 3;
+  const ringPoints = 24;
+  for (let i = 0; i < ringPoints; i++) {
+    const angle = (i / ringPoints) * Math.PI * 2 + time * 0.2;
+    const rx = center + Math.cos(angle) * ringRadius * 2;
+    const ry = center + Math.sin(angle) * ringRadius;
+    const col = Math.round(rx);
+    const row = Math.round(ry);
+    if (row >= 0 && row < size && col >= 0 && col < size * 2) {
+      if (grid[row][col] === " ") {
+        grid[row][col] = palette.dim(i % 3 === 0 ? "◦" : "·");
+      }
+    }
+  }
+
+  return grid.map((row) => row.join(""));
+}
+
 // ─── Registry ───────────────────────────────────────────────────────
 
 export const visualizers: Record<string, VisualizerFn> = {
   "progress-bar": progressBar,
   wave,
   orb,
+  lotus,
 };

--- a/src/visualizers.ts
+++ b/src/visualizers.ts
@@ -23,41 +23,6 @@ function progressBar(
   return [bar];
 }
 
-// ─── Circle ─────────────────────────────────────────────────────────
-
-function circle(
-  progress: number,
-  _phase: string,
-  palette: Palette,
-  _width: number
-): string[] {
-  const maxRadius = 4;
-  const radius = Math.max(1, Math.round(progress * maxRadius));
-  const size = radius * 2 + 1;
-  const lines: string[] = [];
-
-  for (let y = 0; y < size; y++) {
-    let row = "";
-    for (let x = 0; x < size * 2; x++) {
-      const dx = (x / 2) - radius;
-      const dy = y - radius;
-      const dist = Math.sqrt(dx * dx + dy * dy);
-
-      if (Math.abs(dist - radius) < 0.6) {
-        row += palette.accent("·");
-      } else if (dist < 0.8) {
-        row += palette.bar("●");
-      } else if (dist < radius * 0.5 && radius > 2) {
-        row += palette.dim("◦");
-      } else {
-        row += " ";
-      }
-    }
-    lines.push(row);
-  }
-  return lines;
-}
-
 // ─── Wave ───────────────────────────────────────────────────────────
 
 function wave(
@@ -137,47 +102,10 @@ function orb(
   return lines;
 }
 
-// ─── Particles ──────────────────────────────────────────────────────
-
-function particles(
-  progress: number,
-  _phase: string,
-  palette: Palette,
-  width: number
-): string[] {
-  const particleWidth = Math.min(30, width - 10);
-  const rows = 7;
-  const chars = ["·", "°", "•", "✧", "✦"];
-  const grid: string[][] = [];
-
-  for (let r = 0; r < rows; r++) {
-    grid.push(new Array(particleWidth).fill(" "));
-  }
-
-  const seeds = [3, 7, 11, 15, 19, 23, 27, 5, 13, 21, 9, 17, 25, 1, 29];
-  for (let i = 0; i < seeds.length; i++) {
-    const x = seeds[i] % particleWidth;
-    const baseRow = rows - 1 - (i % rows);
-    const offset = Math.round(progress * (rows - 1));
-    const row = baseRow - offset + Math.floor(i / rows);
-    const wrappedRow = ((row % rows) + rows) % rows;
-
-    if (wrappedRow >= 0 && wrappedRow < rows && x < particleWidth) {
-      const ch = chars[i % chars.length];
-      const colorFn = i % 3 === 0 ? palette.bar : i % 3 === 1 ? palette.accent : palette.dim;
-      grid[wrappedRow][x] = colorFn(ch);
-    }
-  }
-
-  return grid.map((row) => row.join(""));
-}
-
 // ─── Registry ───────────────────────────────────────────────────────
 
 export const visualizers: Record<string, VisualizerFn> = {
   "progress-bar": progressBar,
-  circle,
   wave,
   orb,
-  particles,
 };


### PR DESCRIPTION
## Summary
- Empty garden plots now show green dots (`··`) instead of 🌱 so the garden starts as a simple green field
- Players choose exact row/column when placing plants (purchases and trades)
- Occupied spots can be replaced with confirmation prompt

## Test plan
- [ ] Verify empty garden displays as green dot grid
- [ ] Buy a plant and confirm row/column selection works
- [ ] Place a plant on an occupied spot and verify replace prompt appears
- [ ] Trade plants and confirm placement picker appears for the reward

🤖 Generated with [Claude Code](https://claude.com/claude-code)